### PR TITLE
fix: sharing folder set 'send notification about this shared' is checked by default

### DIFF
--- a/src/views/secondary-bar/share-folder-modal.jsx
+++ b/src/views/secondary-bar/share-folder-modal.jsx
@@ -40,7 +40,7 @@ const ShareFolderModal = ({
 	const [ContactInput, integrationAvailable] = useIntegratedComponent('contact-input');
 	const shareFolderWithOptions = useMemo(() => ShareFolderWithOptions(t), [t]);
 	const shareFolderRoleOptions = useMemo(() => ShareFolderRoleOptions(t), [t]);
-	const [sendNotification, setSendNotification] = useState(false);
+	const [sendNotification, setSendNotification] = useState(true);
 	const [standardMessage, setStandardMessage] = useState('');
 	const [contacts, setContacts] = useState([]);
 	const [shareWithUserType, setshareWithUserType] = useState('usr');


### PR DESCRIPTION
fix: sharing folder set 'send notification about this shared' is checked by default