### PR TITLE
Iris 4905 enhance the contact input in order to show the chips with the emails instead of the names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6688,24 +6688,6 @@
 				}
 			}
 		},
-		"node_modules/@zextras/carbonio-shell-ui/node_modules/@zextras/carbonio-design-system": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-3.0.2.tgz",
-			"integrity": "sha512-cd6ekcc9WcYwLgE2mfFRzS+B+ii3TTKWeVcQbMvyiNeJVDL1f9+8viJ7TVUdimhPblqX+9DZxbB2asA6Hr6qlQ==",
-			"dependencies": {
-				"@popperjs/core": "^2.11.8",
-				"darkreader": "4.9.58",
-				"polished": "4.2.2",
-				"react-datepicker": "^4.16.0",
-				"react-docgen-typescript": "^2.2.2"
-			},
-			"peerDependencies": {
-				"lodash": "^4.17.21",
-				"react": "^17.0.2",
-				"react-dom": "^17.0.2",
-				"styled-components": "^5.3.3"
-			}
-		},
 		"node_modules/@zextras/carbonio-shell-ui/node_modules/immer": {
 			"version": "10.0.2",
 			"resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",
@@ -27018,18 +27000,6 @@
 				"zustand": "^4.4.1"
 			},
 			"dependencies": {
-				"@zextras/carbonio-design-system": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/@zextras/carbonio-design-system/-/carbonio-design-system-3.0.2.tgz",
-					"integrity": "sha512-cd6ekcc9WcYwLgE2mfFRzS+B+ii3TTKWeVcQbMvyiNeJVDL1f9+8viJ7TVUdimhPblqX+9DZxbB2asA6Hr6qlQ==",
-					"requires": {
-						"@popperjs/core": "^2.11.8",
-						"darkreader": "4.9.58",
-						"polished": "4.2.2",
-						"react-datepicker": "^4.16.0",
-						"react-docgen-typescript": "^2.2.2"
-					}
-				},
 				"immer": {
 					"version": "10.0.2",
 					"resolved": "https://registry.npmjs.org/immer/-/immer-10.0.2.tgz",

--- a/src/app.jsx
+++ b/src/app.jsx
@@ -18,7 +18,7 @@ import {
 } from '@zextras/carbonio-shell-ui';
 import { useTranslation } from 'react-i18next';
 
-import { CONTACTS_ROUTE, CONTACTS_APP_ID } from './constants';
+import { CONTACTS_APP_ID, CONTACTS_ROUTE } from './constants/app';
 import ContactInput from './integrations/contact-input';
 import { StoreProvider } from './store/redux';
 import SidebarItems from './views/secondary-bar/sidebar';

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2022 Zextras <https://www.zextras.com>
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
  *
  * SPDX-License-Identifier: AGPL-3.0-only
  */

--- a/src/constants/contact-input.ts
+++ b/src/constants/contact-input.ts
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+export const CHIP_DISPLAY_NAME_VALUES = {
+	LABEL: 'label',
+	EMAIL: 'email'
+} as const;

--- a/src/integrations/contact-input-custom-chip-component.test.tsx
+++ b/src/integrations/contact-input-custom-chip-component.test.tsx
@@ -11,8 +11,8 @@ import { rest } from 'msw';
 import { ContactInputCustomChipComponent } from './contact-input-custom-chip-component';
 import { getSetupServer } from '../carbonio-ui-commons/test/jest-setup';
 import { setupTest } from '../carbonio-ui-commons/test/test-setup';
+import { CHIP_DISPLAY_NAME_VALUES } from '../constants/contact-input';
 import { getDistributionListCustomResponse } from '../tests/msw/handle-get-distribution-list-members-request';
-import { CHIP_DISPLAY_NAME_VALUES } from '../types/integrations';
 
 const getDistributionListMembersRequest = '/service/soap/GetDistributionListMembersRequest';
 
@@ -250,7 +250,7 @@ describe('Contact input custom chip component', () => {
 		expect(user5).toBeVisible();
 		expect(user6).toBeVisible();
 
-		expect(showMore).not.toBeVisible();
+		expect(showMore).not.toBeInTheDocument();
 	});
 	test('clicking select all when all data are retrieved, it wont make any other call to the server', async () => {
 		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];

--- a/src/integrations/contact-input-custom-chip-component.test.tsx
+++ b/src/integrations/contact-input-custom-chip-component.test.tsx
@@ -8,13 +8,11 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
 
-import {
-	CHIP_DISPLAY_NAME_VALUES,
-	ContactInputCustomChipComponent
-} from './contact-input-custom-chip-component';
+import { ContactInputCustomChipComponent } from './contact-input-custom-chip-component';
 import { getSetupServer } from '../carbonio-ui-commons/test/jest-setup';
 import { setupTest } from '../carbonio-ui-commons/test/test-setup';
 import { getDistributionListCustomResponse } from '../tests/msw/handle-get-distribution-list-members-request';
+import { CHIP_DISPLAY_NAME_VALUES } from '../types/integrations';
 
 const getDistributionListMembersRequest = '/service/soap/GetDistributionListMembersRequest';
 
@@ -54,7 +52,7 @@ describe('Contact input custom chip component', () => {
 		);
 		const defaultChipLabel = screen.getByText(user1.label);
 
-		expect(defaultChipLabel).toBeInTheDocument();
+		expect(defaultChipLabel).toBeVisible();
 	});
 	test('if chipDisplayName has label value it will show chips label', () => {
 		setupTest(
@@ -70,7 +68,7 @@ describe('Contact input custom chip component', () => {
 		);
 		const defaultChipLabel = screen.getByText(user1.label);
 
-		expect(defaultChipLabel).toBeInTheDocument();
+		expect(defaultChipLabel).toBeVisible();
 	});
 	test('if chipDisplayName has email value it will show chips email', () => {
 		setupTest(
@@ -86,7 +84,7 @@ describe('Contact input custom chip component', () => {
 		);
 		const defaultChipEmail = screen.getByText(user1.email);
 
-		expect(defaultChipEmail).toBeInTheDocument();
+		expect(defaultChipEmail).toBeVisible();
 	});
 	test('if it is a group it will render a normal chip', () => {
 		setupTest(
@@ -101,7 +99,7 @@ describe('Contact input custom chip component', () => {
 		);
 
 		const defaultChip = screen.getByTestId('default-chip');
-		expect(defaultChip).toBeInTheDocument();
+		expect(defaultChip).toBeVisible();
 	});
 	test('if it is a contact it will render a normal chip', () => {
 		setupTest(
@@ -116,7 +114,7 @@ describe('Contact input custom chip component', () => {
 		);
 
 		const defaultChip = screen.getByTestId('default-chip');
-		expect(defaultChip).toBeInTheDocument();
+		expect(defaultChip).toBeVisible();
 	});
 	test('if it is a distribution list it will render the distribution list custom chip', () => {
 		setupTest(
@@ -131,7 +129,7 @@ describe('Contact input custom chip component', () => {
 		);
 
 		const distributionListChip = screen.getByTestId('distribution-list-chip');
-		expect(distributionListChip).toBeInTheDocument();
+		expect(distributionListChip).toBeVisible();
 	});
 	test('the dropdown will contain the select all button and the users list when the chevron action is clicked', async () => {
 		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
@@ -165,10 +163,10 @@ describe('Contact input custom chip component', () => {
 		const user2Element = screen.getByText(user2Mail);
 		const user3Element = screen.getByText(user3Mail);
 
-		expect(selectAllLabel).toBeInTheDocument();
-		expect(user1Element).toBeInTheDocument();
-		expect(user2Element).toBeInTheDocument();
-		expect(user3Element).toBeInTheDocument();
+		expect(selectAllLabel).toBeVisible();
+		expect(user1Element).toBeVisible();
+		expect(user2Element).toBeVisible();
+		expect(user3Element).toBeVisible();
 	});
 	test('the dropdown will contain also the show more button when more results can be retrieved', async () => {
 		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
@@ -200,7 +198,7 @@ describe('Contact input custom chip component', () => {
 
 		const showMore = screen.getByText(/show more/i);
 
-		expect(showMore).toBeInTheDocument();
+		expect(showMore).toBeVisible();
 	});
 	test('clicking show more button will increase the dropdown items, if all items are retrieved show more will disappear', async () => {
 		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
@@ -248,11 +246,11 @@ describe('Contact input custom chip component', () => {
 		const user5 = screen.getByText(user5Mail);
 		const user6 = screen.getByText(user6Mail);
 
-		expect(user4).toBeInTheDocument();
-		expect(user5).toBeInTheDocument();
-		expect(user6).toBeInTheDocument();
+		expect(user4).toBeVisible();
+		expect(user5).toBeVisible();
+		expect(user6).toBeVisible();
 
-		expect(showMore).not.toBeInTheDocument();
+		expect(showMore).not.toBeVisible();
 	});
 	test('clicking select all when all data are retrieved, it wont make any other call to the server', async () => {
 		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];

--- a/src/integrations/contact-input-custom-chip-component.test.tsx
+++ b/src/integrations/contact-input-custom-chip-component.test.tsx
@@ -8,7 +8,10 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
 
-import { ContactInputCustomChipComponent } from './contact-input-custom-chip-component';
+import {
+	CHIP_DISPLAY_NAME_VALUES,
+	ContactInputCustomChipComponent
+} from './contact-input-custom-chip-component';
 import { getSetupServer } from '../carbonio-ui-commons/test/jest-setup';
 import { setupTest } from '../carbonio-ui-commons/test/test-setup';
 import { getDistributionListCustomResponse } from '../tests/msw/handle-get-distribution-list-members-request';
@@ -19,7 +22,12 @@ const dl1Id = 'dl-1';
 const dl1Label = 'dl 1';
 const dl1Mail = 'dl1@mail.com';
 
-const user1Mail = 'user1@mail.com';
+const user1 = {
+	id: 'user1ID',
+	email: 'user1@mail.com',
+	label: 'user1'
+};
+
 const user2Mail = 'user2@mail.com';
 const user3Mail = 'user3@mail.com';
 const user4Mail = 'user4@mail.com';
@@ -31,6 +39,53 @@ const chevronTestId = 'icon: ChevronDownOutline';
 const selectAll = 'Select address';
 
 describe('Contact input custom chip component', () => {
+	test('if chipDisplayName is not passed it will show chips label by default', () => {
+		setupTest(
+			<ContactInputCustomChipComponent
+				id={user1.id}
+				label={user1.label}
+				email={user1.email}
+				isGroup={false}
+				_onChange={jest.fn()}
+				contactInputValue={[]}
+			/>
+		);
+		const defaultChipLabel = screen.getByText(user1.label);
+
+		expect(defaultChipLabel).toBeInTheDocument();
+	});
+	test('if chipDisplayName has label value it will show chips label', () => {
+		setupTest(
+			<ContactInputCustomChipComponent
+				id={user1.id}
+				label={user1.label}
+				email={user1.email}
+				isGroup={false}
+				_onChange={jest.fn()}
+				contactInputValue={[]}
+				chipDisplayName={CHIP_DISPLAY_NAME_VALUES.LABEL}
+			/>
+		);
+		const defaultChipLabel = screen.getByText(user1.label);
+
+		expect(defaultChipLabel).toBeInTheDocument();
+	});
+	test('if chipDisplayName has email value it will show chips email', () => {
+		setupTest(
+			<ContactInputCustomChipComponent
+				id={user1.id}
+				label={user1.label}
+				email={user1.email}
+				isGroup={false}
+				_onChange={jest.fn()}
+				contactInputValue={[]}
+				chipDisplayName={CHIP_DISPLAY_NAME_VALUES.EMAIL}
+			/>
+		);
+		const defaultChipEmail = screen.getByText(user1.email);
+
+		expect(defaultChipEmail).toBeInTheDocument();
+	});
 	test('if it is a group it will render a normal chip', () => {
 		setupTest(
 			<ContactInputCustomChipComponent
@@ -49,9 +104,9 @@ describe('Contact input custom chip component', () => {
 	test('if it is a contact it will render a normal chip', () => {
 		setupTest(
 			<ContactInputCustomChipComponent
-				id={'user-1'}
-				label={'user 1'}
-				email={user1Mail}
+				id={user1.id}
+				label={user1.label}
+				email={user1.email}
 				isGroup={false}
 				_onChange={jest.fn()}
 				contactInputValue={[]}
@@ -77,7 +132,7 @@ describe('Contact input custom chip component', () => {
 		expect(distributionListChip).toBeInTheDocument();
 	});
 	test('the dropdown will contain the select all button and the users list when the chevron action is clicked', async () => {
-		const dlm = [{ _content: user1Mail }, { _content: user2Mail }, { _content: user3Mail }];
+		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
 		const total = 3;
 		const more = false;
 		const response = getDistributionListCustomResponse({ dlm, total, more });
@@ -104,17 +159,17 @@ describe('Contact input custom chip component', () => {
 		});
 
 		const selectAllLabel = screen.getByText(selectAll);
-		const user1 = screen.getByText(user1Mail);
-		const user2 = screen.getByText(user2Mail);
-		const user3 = screen.getByText(user3Mail);
+		const user1Element = screen.getByText(user1.email);
+		const user2Element = screen.getByText(user2Mail);
+		const user3Element = screen.getByText(user3Mail);
 
 		expect(selectAllLabel).toBeInTheDocument();
-		expect(user1).toBeInTheDocument();
-		expect(user2).toBeInTheDocument();
-		expect(user3).toBeInTheDocument();
+		expect(user1Element).toBeInTheDocument();
+		expect(user2Element).toBeInTheDocument();
+		expect(user3Element).toBeInTheDocument();
 	});
 	test('the dropdown will contain also the show more button when more results can be retrieved', async () => {
-		const dlm = [{ _content: user1Mail }, { _content: user2Mail }, { _content: user3Mail }];
+		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
 		const total = 6;
 		const more = true;
 		const response = getDistributionListCustomResponse({ dlm, total, more });
@@ -146,7 +201,7 @@ describe('Contact input custom chip component', () => {
 		expect(showMore).toBeInTheDocument();
 	});
 	test('clicking show more button will increase the dropdown items, if all items are retrieved show more will disappear', async () => {
-		const dlm = [{ _content: user1Mail }, { _content: user2Mail }, { _content: user3Mail }];
+		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
 		const dlm2 = [{ _content: user4Mail }, { _content: user5Mail }, { _content: user6Mail }];
 
 		const firstResponse = getDistributionListCustomResponse({ dlm, total: 6, more: true });
@@ -198,7 +253,7 @@ describe('Contact input custom chip component', () => {
 		expect(showMore).not.toBeInTheDocument();
 	});
 	test('clicking select all when all data are retrieved, it wont make any other call to the server', async () => {
-		const dlm = [{ _content: user1Mail }, { _content: user2Mail }, { _content: user3Mail }];
+		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
 		const response = getDistributionListCustomResponse({ dlm, total: 3, more: false });
 		const dispatchRequest = jest.fn();
 
@@ -231,7 +286,7 @@ describe('Contact input custom chip component', () => {
 		expect(dispatchRequest).toHaveBeenCalledTimes(1);
 	});
 	test('clicking select all when more data are available, it will make another call to the server', async () => {
-		const dlm = [{ _content: user1Mail }, { _content: user2Mail }, { _content: user3Mail }];
+		const dlm = [{ _content: user1.email }, { _content: user2Mail }, { _content: user3Mail }];
 		const dlm2 = [{ _content: user4Mail }, { _content: user5Mail }, { _content: user6Mail }];
 		const firstResponse = getDistributionListCustomResponse({ dlm, total: 6, more: true });
 		const secondResponse = getDistributionListCustomResponse({ dlm: dlm2, total: 6, more: false });

--- a/src/integrations/contact-input-custom-chip-component.test.tsx
+++ b/src/integrations/contact-input-custom-chip-component.test.tsx
@@ -18,9 +18,11 @@ import { getDistributionListCustomResponse } from '../tests/msw/handle-get-distr
 
 const getDistributionListMembersRequest = '/service/soap/GetDistributionListMembersRequest';
 
-const dl1Id = 'dl-1';
-const dl1Label = 'dl 1';
-const dl1Mail = 'dl1@mail.com';
+const distributionList = {
+	id: 'dl-1',
+	email: 'dl1@mail.com',
+	label: 'dl 1'
+};
 
 const user1 = {
 	id: 'user1ID',
@@ -119,9 +121,9 @@ describe('Contact input custom chip component', () => {
 	test('if it is a distribution list it will render the distribution list custom chip', () => {
 		setupTest(
 			<ContactInputCustomChipComponent
-				id={dl1Id}
-				label={dl1Label}
-				email={dl1Mail}
+				id={distributionList.id}
+				label={distributionList.label}
+				email={distributionList.email}
 				isGroup
 				_onChange={jest.fn()}
 				contactInputValue={[]}
@@ -143,9 +145,9 @@ describe('Contact input custom chip component', () => {
 
 		const { user } = setupTest(
 			<ContactInputCustomChipComponent
-				id={dl1Id}
-				label={dl1Label}
-				email={dl1Mail}
+				id={distributionList.id}
+				label={distributionList.label}
+				email={distributionList.email}
 				isGroup
 				_onChange={jest.fn()}
 				contactInputValue={[]}
@@ -180,9 +182,9 @@ describe('Contact input custom chip component', () => {
 
 		const { user } = setupTest(
 			<ContactInputCustomChipComponent
-				id={dl1Id}
-				label={dl1Label}
-				email={dl1Mail}
+				id={distributionList.id}
+				label={distributionList.label}
+				email={distributionList.email}
 				isGroup
 				_onChange={jest.fn()}
 				contactInputValue={[]}
@@ -215,9 +217,9 @@ describe('Contact input custom chip component', () => {
 
 		const { user } = setupTest(
 			<ContactInputCustomChipComponent
-				id={dl1Id}
-				label={dl1Label}
-				email={dl1Mail}
+				id={distributionList.id}
+				label={distributionList.label}
+				email={distributionList.email}
 				isGroup
 				_onChange={jest.fn()}
 				contactInputValue={[]}
@@ -263,9 +265,9 @@ describe('Contact input custom chip component', () => {
 		getSetupServer().events.on('request:start', dispatchRequest);
 		const { user } = setupTest(
 			<ContactInputCustomChipComponent
-				id={dl1Id}
-				label={dl1Label}
-				email={dl1Mail}
+				id={distributionList.id}
+				label={distributionList.label}
+				email={distributionList.email}
 				isGroup
 				_onChange={jest.fn()}
 				contactInputValue={[]}
@@ -309,9 +311,9 @@ describe('Contact input custom chip component', () => {
 
 		const { user } = setupTest(
 			<ContactInputCustomChipComponent
-				id={dl1Id}
-				label={dl1Label}
-				email={dl1Mail}
+				id={distributionList.id}
+				label={distributionList.label}
+				email={distributionList.email}
 				isGroup
 				_onChange={jest.fn()}
 				contactInputValue={[]}

--- a/src/integrations/contact-input-custom-chip-component.tsx
+++ b/src/integrations/contact-input-custom-chip-component.tsx
@@ -13,12 +13,8 @@ import { debounce, DebouncedFuncLeading, filter, map, noop, uniqBy } from 'lodas
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import {
-	CHIP_DISPLAY_NAME_VALUES,
-	ContactInputOnChange,
-	ContactInputValue,
-	CustomChipProps
-} from '../types/integrations';
+import { CHIP_DISPLAY_NAME_VALUES } from '../constants/contact-input';
+import { ContactInputOnChange, ContactInputValue, CustomChipProps } from '../types/integrations';
 
 const StyledChip = styled(Chip)`
 	cursor: default;

--- a/src/integrations/contact-input-custom-chip-component.tsx
+++ b/src/integrations/contact-input-custom-chip-component.tsx
@@ -15,6 +15,11 @@ import styled from 'styled-components';
 
 import { ContactInputOnChange, ContactInputValue, CustomChipProps } from '../types/integrations';
 
+export const CHIP_DISPLAY_NAME_VALUES = {
+	LABEL: 'label',
+	EMAIL: 'email'
+};
+
 const StyledChip = styled(Chip)`
 	cursor: default;
 	&:hover {
@@ -278,10 +283,20 @@ const CustomComponent = (props: CustomChipProps): JSX.Element => {
 };
 
 export const ContactInputCustomChipComponent = (props: CustomChipProps): ReactElement => {
-	const { email, isGroup } = props;
+	const { email, isGroup, label, chipDisplayName = CHIP_DISPLAY_NAME_VALUES.LABEL } = props;
+
+	const _label = useMemo(() => {
+		if (label && chipDisplayName === CHIP_DISPLAY_NAME_VALUES.LABEL) {
+			return label;
+		}
+		if (email && chipDisplayName === CHIP_DISPLAY_NAME_VALUES.EMAIL) {
+			return email;
+		}
+		return label ?? email ?? '';
+	}, [chipDisplayName, email, label]);
 
 	if (!isDistributionList({ email, isGroup })) {
-		return <Chip {...props} data-testid={'default-chip'} />;
+		return <Chip {...props} label={_label} data-testid={'default-chip'} />;
 	}
-	return <CustomComponent {...props} />;
+	return <CustomComponent {...props} label={_label} />;
 };

--- a/src/integrations/contact-input-custom-chip-component.tsx
+++ b/src/integrations/contact-input-custom-chip-component.tsx
@@ -13,12 +13,12 @@ import { debounce, DebouncedFuncLeading, filter, map, noop, uniqBy } from 'lodas
 import { useTranslation } from 'react-i18next';
 import styled from 'styled-components';
 
-import { ContactInputOnChange, ContactInputValue, CustomChipProps } from '../types/integrations';
-
-export const CHIP_DISPLAY_NAME_VALUES = {
-	LABEL: 'label',
-	EMAIL: 'email'
-};
+import {
+	CHIP_DISPLAY_NAME_VALUES,
+	ContactInputOnChange,
+	ContactInputValue,
+	CustomChipProps
+} from '../types/integrations';
 
 const StyledChip = styled(Chip)`
 	cursor: default;
@@ -228,8 +228,15 @@ const useDistributionListFunctions = ({
 	return { items, onChevronClick };
 };
 
-const CustomComponent = (props: CustomChipProps): JSX.Element => {
-	const { id, label, email, isGroup, _onChange, contactInputValue } = props;
+const CustomComponent = ({
+	id,
+	label,
+	email,
+	isGroup,
+	_onChange,
+	contactInputValue,
+	...rest
+}: CustomChipProps): JSX.Element => {
 	const [t] = useTranslation();
 	const [open, setOpen] = useState(false);
 
@@ -255,7 +262,7 @@ const CustomComponent = (props: CustomChipProps): JSX.Element => {
 		>
 			<div>
 				<StyledChip
-					{...props}
+					{...rest}
 					id={id}
 					label={label}
 					background={'gray3'}
@@ -282,9 +289,13 @@ const CustomComponent = (props: CustomChipProps): JSX.Element => {
 	);
 };
 
-export const ContactInputCustomChipComponent = (props: CustomChipProps): ReactElement => {
-	const { email, isGroup, label, chipDisplayName = CHIP_DISPLAY_NAME_VALUES.LABEL } = props;
-
+export const ContactInputCustomChipComponent = ({
+	email,
+	isGroup,
+	label,
+	chipDisplayName = CHIP_DISPLAY_NAME_VALUES.LABEL,
+	...rest
+}: CustomChipProps): ReactElement => {
 	const _label = useMemo(() => {
 		if (label && chipDisplayName === CHIP_DISPLAY_NAME_VALUES.LABEL) {
 			return label;
@@ -296,7 +307,7 @@ export const ContactInputCustomChipComponent = (props: CustomChipProps): ReactEl
 	}, [chipDisplayName, email, label]);
 
 	if (!isDistributionList({ email, isGroup })) {
-		return <Chip {...props} label={_label} data-testid={'default-chip'} />;
+		return <Chip {...rest} label={_label} data-testid={'default-chip'} />;
 	}
-	return <CustomComponent {...props} label={_label} />;
+	return <CustomComponent {...rest} label={_label} email={email} isGroup={isGroup} />;
 };

--- a/src/integrations/contact-input.tsx
+++ b/src/integrations/contact-input.tsx
@@ -300,7 +300,7 @@ const ContactInput: FC<ContactInput> = ({
 						customComponent: <Loader />
 					}
 				]);
-				new Promise((resolve, _reject) => {
+				new Promise((resolve, promiseReject) => {
 					try {
 						resolve(
 							filter(allContacts, (c) =>
@@ -310,7 +310,7 @@ const ContactInput: FC<ContactInput> = ({
 							)
 						);
 					} catch (err: any) {
-						_reject(new Error(err));
+						promiseReject(new Error(err));
 					}
 				})
 					.then((localResults: any) => {

--- a/src/integrations/contact-input.tsx
+++ b/src/integrations/contact-input.tsx
@@ -35,7 +35,10 @@ import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 import styled, { DefaultTheme } from 'styled-components';
 
-import { ContactInputCustomChipComponent } from './contact-input-custom-chip-component';
+import {
+	CHIP_DISPLAY_NAME_VALUES,
+	ContactInputCustomChipComponent
+} from './contact-input-custom-chip-component';
 import { useAppSelector } from '../hooks/redux';
 import { StoreProvider } from '../store/redux';
 import { Contact, Group } from '../types/contact';
@@ -139,6 +142,7 @@ type ContactInput = {
 	defaultValue: Array<Contact>;
 	placeholder: string;
 	background?: keyof DefaultTheme['palette'];
+	chipDisplayName?: string;
 	dragAndDropEnabled?: boolean;
 };
 
@@ -148,6 +152,7 @@ const ContactInput: FC<ContactInput> = ({
 	placeholder,
 	background = 'gray5',
 	dragAndDropEnabled = false,
+	chipDisplayName = CHIP_DISPLAY_NAME_VALUES.LABEL,
 	...rest
 }) => {
 	const props = omit(rest, 'ChipComponent');
@@ -293,7 +298,7 @@ const ContactInput: FC<ContactInput> = ({
 						customComponent: <Loader />
 					}
 				]);
-				new Promise((resolve, reject) => {
+				new Promise((resolve, _reject) => {
 					try {
 						resolve(
 							filter(allContacts, (c) =>
@@ -303,7 +308,7 @@ const ContactInput: FC<ContactInput> = ({
 							)
 						);
 					} catch (err: any) {
-						reject(new Error(err));
+						_reject(new Error(err));
 					}
 				})
 					.then((localResults: any) => {
@@ -459,11 +464,12 @@ const ContactInput: FC<ContactInput> = ({
 		(_props: CustomChipProps): React.JSX.Element => (
 			<ContactInputCustomChipComponent
 				{..._props}
+				chipDisplayName={chipDisplayName}
 				_onChange={onChange}
 				contactInputValue={contactInputValue}
 			/>
 		),
-		[contactInputValue, onChange]
+		[chipDisplayName, contactInputValue, onChange]
 	);
 
 	const onDragEnter = useCallback((ev) => {

--- a/src/integrations/contact-input.tsx
+++ b/src/integrations/contact-input.tsx
@@ -36,12 +36,13 @@ import { useTranslation } from 'react-i18next';
 import styled, { DefaultTheme } from 'styled-components';
 
 import { ContactInputCustomChipComponent } from './contact-input-custom-chip-component';
+import { CHIP_DISPLAY_NAME_VALUES } from '../constants/contact-input';
 import { parseFullAutocompleteXML } from '../helpers/autocomplete';
 import { useAppSelector } from '../hooks/redux';
 import { StoreProvider } from '../store/redux';
 import { Contact, Group } from '../types/contact';
 import {
-	CHIP_DISPLAY_NAME_VALUES,
+	ContactInputChipDisplayName,
 	ContactInputOnChange,
 	ContactInputValue,
 	CustomChipProps
@@ -145,7 +146,7 @@ type ContactInput = {
 	defaultValue: Array<Contact>;
 	placeholder: string;
 	background?: keyof DefaultTheme['palette'];
-	chipDisplayName?: (typeof CHIP_DISPLAY_NAME_VALUES)[keyof typeof CHIP_DISPLAY_NAME_VALUES];
+	chipDisplayName?: ContactInputChipDisplayName;
 	dragAndDropEnabled?: boolean;
 	extraAccountsIds: Array<string>;
 };

--- a/src/integrations/contact-input.tsx
+++ b/src/integrations/contact-input.tsx
@@ -35,14 +35,16 @@ import moment from 'moment';
 import { useTranslation } from 'react-i18next';
 import styled, { DefaultTheme } from 'styled-components';
 
-import {
-	CHIP_DISPLAY_NAME_VALUES,
-	ContactInputCustomChipComponent
-} from './contact-input-custom-chip-component';
+import { ContactInputCustomChipComponent } from './contact-input-custom-chip-component';
 import { useAppSelector } from '../hooks/redux';
 import { StoreProvider } from '../store/redux';
 import { Contact, Group } from '../types/contact';
-import { ContactInputOnChange, ContactInputValue, CustomChipProps } from '../types/integrations';
+import {
+	CHIP_DISPLAY_NAME_VALUES,
+	ContactInputOnChange,
+	ContactInputValue,
+	CustomChipProps
+} from '../types/integrations';
 import { ContactsSlice, State } from '../types/store';
 
 const emailRegex = /[^\s@]+@[^\s@]+\.[^\s@]+/;
@@ -142,7 +144,7 @@ type ContactInput = {
 	defaultValue: Array<Contact>;
 	placeholder: string;
 	background?: keyof DefaultTheme['palette'];
-	chipDisplayName?: string;
+	chipDisplayName?: (typeof CHIP_DISPLAY_NAME_VALUES)[keyof typeof CHIP_DISPLAY_NAME_VALUES];
 	dragAndDropEnabled?: boolean;
 };
 

--- a/src/store/redux/index.tsx
+++ b/src/store/redux/index.tsx
@@ -6,7 +6,7 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import React, { FC } from 'react';
 import { Provider } from 'react-redux';
-import { CONTACTS_APP_ID } from '../../constants';
+import { CONTACTS_APP_ID } from '../../constants/app';
 import { storeReducers } from '../reducers/reducers';
 
 export default combineReducers({});

--- a/src/tests/generators/store.ts
+++ b/src/tests/generators/store.ts
@@ -6,7 +6,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 
 import { configureStore, EnhancedStore } from '@reduxjs/toolkit';
-import { CONTACTS_APP_ID } from '../../constants';
+import { CONTACTS_APP_ID } from '../../constants/app';
 import { storeReducers } from '../../store/reducers/reducers';
 
 type StateType = {

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -9,6 +9,11 @@ import { ChipItem } from '@zextras/carbonio-design-system';
 
 import { Contact } from './contact';
 
+export const CHIP_DISPLAY_NAME_VALUES = {
+	LABEL: 'label',
+	EMAIL: 'email'
+} as const;
+
 export type ContactInputValue = Array<
 	ChipItem<string | Contact | ((prevState: ChipItem<string | Contact>[]) => ChipItem[])>
 >;
@@ -19,7 +24,7 @@ export type CustomChipProps = React.PropsWithChildren<{
 	label: string;
 	email: string;
 	isGroup: boolean;
-	chipDisplayName?: string;
+	chipDisplayName?: (typeof CHIP_DISPLAY_NAME_VALUES)[keyof typeof CHIP_DISPLAY_NAME_VALUES];
 	_onChange: ContactInputOnChange;
 	contactInputValue: ContactInputValue;
 }>;

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -8,23 +8,22 @@ import React from 'react';
 import { ChipItem } from '@zextras/carbonio-design-system';
 
 import { Contact } from './contact';
-
-export const CHIP_DISPLAY_NAME_VALUES = {
-	LABEL: 'label',
-	EMAIL: 'email'
-} as const;
+import { CHIP_DISPLAY_NAME_VALUES } from '../constants/contact-input';
 
 export type ContactInputValue = Array<
 	ChipItem<string | Contact | ((prevState: ChipItem<string | Contact>[]) => ChipItem[])>
 >;
 
 export type ContactInputOnChange = ((items: ContactInputValue) => void) | undefined;
+export type ContactInputChipDisplayName =
+	(typeof CHIP_DISPLAY_NAME_VALUES)[keyof typeof CHIP_DISPLAY_NAME_VALUES];
+
 export type CustomChipProps = React.PropsWithChildren<{
 	id: string;
 	label: string;
 	email: string;
 	isGroup: boolean;
-	chipDisplayName?: (typeof CHIP_DISPLAY_NAME_VALUES)[keyof typeof CHIP_DISPLAY_NAME_VALUES];
+	chipDisplayName?: ContactInputChipDisplayName;
 	_onChange: ContactInputOnChange;
 	contactInputValue: ContactInputValue;
 }>;

--- a/src/types/integrations.ts
+++ b/src/types/integrations.ts
@@ -19,6 +19,7 @@ export type CustomChipProps = React.PropsWithChildren<{
 	label: string;
 	email: string;
 	isGroup: boolean;
+	chipDisplayName?: string;
 	_onChange: ContactInputOnChange;
 	contactInputValue: ContactInputValue;
 }>;


### PR DESCRIPTION
Added a prop to the contact input in order to customize te chip display name. Current possible values are label and email and can be expanded to more values.

refs: IRIS-4905