### PR TITLE
refactor: change the icon associated to the editing of a DL

### DIFF
--- a/src/actions/edit-dl.test.tsx
+++ b/src/actions/edit-dl.test.tsx
@@ -21,7 +21,7 @@ describe('useActionEditDL', () => {
 		const { result } = setupHook(useActionEditDL);
 		expect(result.current).toEqual<UIAction<unknown, unknown>>(
 			expect.objectContaining({
-				icon: 'Edit2Outline',
+				icon: 'Settings2Outline',
 				label: 'Edit distribution list',
 				id: 'dl-edit-action'
 			})

--- a/src/actions/edit-dl.tsx
+++ b/src/actions/edit-dl.tsx
@@ -59,7 +59,7 @@ export const useActionEditDL = (): EditDLAction => {
 		() => ({
 			id: ACTION_IDS.editDL,
 			label: t('action.edit_distribution_list', 'Edit distribution list'),
-			icon: 'Edit2Outline',
+			icon: 'Settings2Outline',
 			execute,
 			canExecute
 		}),

--- a/src/constants/tests.ts
+++ b/src/constants/tests.ts
@@ -10,7 +10,7 @@ export const TESTID_SELECTORS = {
 		trash: /icon: Trash2Outline/i,
 		avatar: /icon: PeopleOutline/i,
 		editChip: 'icon: EditOutline',
-		editDL: 'icon: Edit2Outline',
+		editDL: 'icon: Settings2Outline',
 		expandDL: 'icon: ChevronDownOutline',
 		collapseDL: 'icon: ChevronUpOutline',
 		filterMembers: 'icon: FunnelOutline',


### PR DESCRIPTION
Change the icon for the DL editing action

Refs: IRIS-4975