### PR TITLE
ci: add build:dev script for dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
 		"lint-errors": "eslint --ext .js,.jsx,.ts,.tsx --quiet --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
 		"lint-stats": "eslint --ext .js,.jsx,.ts,.tsx --format node_modules/eslint-stats/byErrorAndWarningStacked --resolve-plugins-relative-to node_modules/@zextras/carbonio-ui-configs src",
 		"pull-translations": "git subtree pull -P translations git@github.com:Zextras/carbonio-contacts-ui-i18n.git master --squash",
-		"push-translations": "git subtree push -P translations git@github.com:Zextras/carbonio-contacts-ui-i18n.git"
+		"push-translations": "git subtree push -P translations git@github.com:Zextras/carbonio-contacts-ui-i18n.git",
+		"build:dev": "sdk build --dev --pkgRel $(date +%s)"
 	},
 	"keywords": [],
 	"author": "Zextras Crab Onions Team <https://www.zextras.com/carbonio/>",


### PR DESCRIPTION
To make common pipeline support different bundlers, we need to remove references to the sdk from it and move them inside projects scripts. build:dev is the script in charge of creating the build in dev mode. Related to zextras/jenkins-zapp-lib#13