### PR TITLE
CO-1250: fix some missing translations

### DIFF
--- a/src/legacy/views/edit/edit-view.jsx
+++ b/src/legacy/views/edit/edit-view.jsx
@@ -404,12 +404,12 @@ export default function EditView({ panel, onClose, onTitleChanged }) {
 				/>
 				<CustomMultivalueField
 					name="URL"
-					label={t('label.website')}
+					label={t('label.website', 'Website')}
 					typeLabel={t('select.default', 'Select type')}
 					typeField="type"
 					types={defaultTypes}
 					subFields={['url']}
-					fieldLabels={[t('label.website', 'Website')]}
+					fieldLabels={[t('section.field.website', 'Website URL')]}
 					value={contact.URL}
 					dispatch={dispatch}
 				/>

--- a/src/legacy/views/search/parts/keyword-row.tsx
+++ b/src/legacy/views/search/parts/keyword-row.tsx
@@ -6,7 +6,7 @@
 import React, { FC, ReactElement, useCallback } from 'react';
 
 import { Container, ChipInput, ChipProps } from '@zextras/carbonio-design-system';
-import { t } from '@zextras/carbonio-shell-ui';
+import { useTranslation } from 'react-i18next';
 
 import { Query } from '../search-types';
 
@@ -31,6 +31,7 @@ type ComponentProps = {
 };
 const KeywordRow: FC<ComponentProps> = ({ compProps }): ReactElement => {
 	const { otherKeywords, setOtherKeywords, query } = compProps;
+	const [t] = useTranslation();
 	const keywordChipOnAdd = useCallback(
 		(label) => ({
 			label,

--- a/src/legacy/views/search/parts/keyword-row.tsx
+++ b/src/legacy/views/search/parts/keyword-row.tsx
@@ -6,6 +6,7 @@
 import React, { FC, ReactElement, useCallback } from 'react';
 
 import { Container, ChipInput, ChipProps } from '@zextras/carbonio-design-system';
+import { t } from '@zextras/carbonio-shell-ui';
 
 import { Query } from '../search-types';
 
@@ -48,7 +49,7 @@ const KeywordRow: FC<ComponentProps> = ({ compProps }): ReactElement => {
 	return (
 		<Container padding={{ bottom: 'small', top: 'medium' }}>
 			<ChipInput
-				placeholder="Keyword"
+				placeholder={t('label.keyword', 'Keyword')}
 				background="gray5"
 				value={otherKeywords}
 				onChange={onChange}


### PR DESCRIPTION
Ref: CO-1250

 * selection_044: :heavy_check_mark:  website field in new contact
 * selection_049: :heavy_check_mark:  keyword placeholder in advanced filters

New weblate keys:
 * label.website
 * section.field.website
 * label.keyword

Weblate keys to check:
 * label.export_contact