### PR TITLE
fix: [CO-1621] avoid adding duplicate contact and contact group items to the store

### DIFF
--- a/src/legacy/utils/helpers.ts
+++ b/src/legacy/utils/helpers.ts
@@ -133,12 +133,17 @@ export function addContactsToStore(
 ): void {
 	reduce(
 		contacts,
-		(acc, v) => {
-			if (!acc[sharedFolderParent ?? v.parent]) {
+		(acc, contact) => {
+			const parentKey = sharedFolderParent ?? contact.parent;
+			if (!acc[parentKey]) {
 				// eslint-disable-next-line no-param-reassign
-				acc[sharedFolderParent ?? v.parent] = [];
+				acc[parentKey] = [];
 			}
-			acc[sharedFolderParent ?? v.parent].push(v);
+
+			if (!acc[parentKey].some((existingContact) => existingContact.id === contact.id)) {
+				acc[parentKey].push(contact);
+			}
+
 			return acc;
 		},
 		state.contacts

--- a/src/legacy/utils/tests/helpers.test.ts
+++ b/src/legacy/utils/tests/helpers.test.ts
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: 2024 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import { Contact } from '../../types/contact';
+import { ContactsSlice } from '../../types/store';
+import { addContactsToStore } from '../helpers';
+
+describe('addContactsToStore', () => {
+	let initialState: ContactsSlice;
+
+	beforeEach(() => {
+		initialState = {
+			status: {},
+			contacts: {},
+			searchedInFolder: {}
+		};
+	});
+
+	const createContact = (id: string, parent: string): Contact => ({
+		id,
+		parent,
+		firstName: 'John',
+		middleName: '',
+		lastName: 'Doe',
+		nickName: 'Johnny',
+		displayName: 'John Doe',
+		address: {},
+		company: 'Test Company',
+		department: 'Testing',
+		email: {},
+		image: '',
+		jobTitle: 'Tester',
+		notes: '',
+		phone: {},
+		nameSuffix: '',
+		namePrefix: 'Mr.',
+		URL: {},
+		fileAsStr: 'Doe, John'
+	});
+
+	it('should add contacts under the correct parent key', () => {
+		const contacts = [createContact('1', 'folder1'), createContact('2', 'folder1')];
+
+		addContactsToStore(initialState, contacts);
+
+		expect(initialState.contacts.folder1).toEqual(contacts);
+	});
+
+	it('should add contacts under sharedFolderParent if specified', () => {
+		const contacts = [createContact('1', 'folder1'), createContact('2', 'folder1')];
+
+		addContactsToStore(initialState, contacts, 'sharedFolder');
+
+		expect(initialState.contacts.sharedFolder).toEqual(contacts);
+	});
+
+	it('should prevent duplicate contacts based on id', () => {
+		const contacts = [createContact('1', 'folder1'), createContact('2', 'folder1')];
+
+		addContactsToStore(initialState, contacts);
+		addContactsToStore(initialState, contacts);
+
+		expect(initialState.contacts.folder1).toEqual(contacts);
+		expect(initialState.contacts.folder1).toHaveLength(2); // Length should be 2, not 4
+	});
+
+	it('should add new contacts without affecting existing contacts under the same parent key', () => {
+		const initialContacts = [createContact('1', 'folder1')];
+		const newContacts = [createContact('2', 'folder1')];
+
+		addContactsToStore(initialState, initialContacts);
+		addContactsToStore(initialState, newContacts);
+
+		expect(initialState.contacts.folder1).toEqual([...initialContacts, ...newContacts]);
+	});
+
+	it('should add new contacts without affecting other parent keys', () => {
+		const folder1Contacts = [createContact('1', 'folder1')];
+		const folder2Contacts = [createContact('2', 'folder2')];
+
+		addContactsToStore(initialState, folder1Contacts);
+		addContactsToStore(initialState, folder2Contacts);
+
+		expect(initialState.contacts.folder1).toEqual(folder1Contacts);
+		expect(initialState.contacts.folder2).toEqual(folder2Contacts);
+	});
+});

--- a/src/store/contact-groups.test.ts
+++ b/src/store/contact-groups.test.ts
@@ -79,6 +79,15 @@ describe('Contact groups store', () => {
 			expect(useContactGroupStore.getState().orderedContactGroups).toEqual([...page1, ...page2]);
 			expect(useContactGroupStore.getState().unorderedContactGroups).toHaveLength(1);
 		});
+
+		it('should prevent duplicate contact groups in orderedContactGroups', () => {
+			const initialList = times(3, () => buildContactGroup());
+			addContactGroups(initialList);
+
+			addContactGroups(initialList);
+
+			expect(useContactGroupStore.getState().orderedContactGroups).toEqual(initialList);
+		});
 	});
 	describe('addSharedContactGroup', () => {
 		it('should return a key value correspondence of the list that has been set', () => {

--- a/src/store/contact-groups.ts
+++ b/src/store/contact-groups.ts
@@ -184,18 +184,21 @@ export const useContactGroupStore = create<State & ContactGroupStoreActions>()((
 	addContactGroups: (contactGroups): void => {
 		const { orderedContactGroups, unorderedContactGroups } = get();
 
+		const newGroups = differenceBy(contactGroups, orderedContactGroups, (cg) => cg.id);
+
 		if (unorderedContactGroups.length > 0) {
 			const unorderedResult = differenceBy(unorderedContactGroups, contactGroups, (cg) => cg.id);
 			set(() => ({
-				orderedContactGroups: [...(orderedContactGroups ?? []), ...contactGroups],
+				orderedContactGroups: [...(orderedContactGroups ?? []), ...newGroups],
 				unorderedContactGroups: unorderedResult
 			}));
 		} else {
 			set(() => ({
-				orderedContactGroups: [...(orderedContactGroups ?? []), ...contactGroups]
+				orderedContactGroups: [...(orderedContactGroups ?? []), ...newGroups]
 			}));
 		}
 	},
+
 	removeContactGroup: (contactGroupId: string): void => {
 		const { orderedContactGroups, unorderedContactGroups, offset } = get();
 		const idx = orderedContactGroups.findIndex(


### PR DESCRIPTION
This avoids adding duplicate contacts and contact groups to the store if the component re-mounts multiple times. See ticket description for more details.