### PR TITLE
[CO-1953] remove shell constants

### DIFF
--- a/src/app/integrations-registration.tsx
+++ b/src/app/integrations-registration.tsx
@@ -7,7 +7,6 @@ import { FC, useEffect, useMemo } from 'react';
 
 import { useSnackbar } from '@zextras/carbonio-design-system';
 import {
-	ACTION_TYPES,
 	addBoard,
 	NewAction,
 	registerActions,
@@ -71,11 +70,11 @@ export const IntegrationsRegistration: FC = () => {
 			{
 				action: () => newContactAction,
 				id: 'new-contact',
-				type: ACTION_TYPES.NEW
+				type: 'new'
 			},
 			{
 				id: 'new-contact-group',
-				type: ACTION_TYPES.NEW,
+				type: 'new',
 				action: () => newContactGroupAction
 			}
 		);

--- a/src/app/tests/integrations-registration.test.tsx
+++ b/src/app/tests/integrations-registration.test.tsx
@@ -5,12 +5,7 @@
  */
 import React from 'react';
 
-import {
-	ACTION_TYPES,
-	registerActions,
-	registerComponents,
-	registerFunctions
-} from '@zextras/carbonio-shell-ui';
+import { registerActions, registerComponents, registerFunctions } from '@zextras/carbonio-shell-ui';
 
 import { setupTest } from '../../carbonio-ui-commons/test/test-setup';
 import { IntegrationsRegistration } from '../integrations-registration';
@@ -40,12 +35,12 @@ describe('IntegrationsRegistration', () => {
 		expect(registerActions).toHaveBeenCalledWith(
 			{
 				id: 'new-contact',
-				type: ACTION_TYPES.NEW,
+				type: 'new',
 				action: expect.any(Function)
 			},
 			{
 				id: 'new-contact-group',
-				type: ACTION_TYPES.NEW,
+				type: 'new',
 				action: expect.any(Function)
 			}
 		);


### PR DESCRIPTION
- Replaced `ACTION_TYPES.NEW` with string literal `new` in test cases
- Adjusted imports to match updated implementation in the source file