### PR TITLE
fix: [CO-1969] contacts on folder shared with me are not visible

### DIFF
--- a/src/legacy/store/contacts.ts
+++ b/src/legacy/store/contacts.ts
@@ -91,11 +91,9 @@ export const useContactById = (contactId: string): Contact | undefined =>
 		return undefined;
 	});
 
-export const useCurrentFolderViewList = (folderId: string): Array<ContactOrGroup> =>
+export const useContactsByParent = (parent: string): Array<ContactOrGroup> =>
 	useContactsStore(({ contacts, currentFolderViewList }) =>
 		Array.from(currentFolderViewList)
 			.map((key: string) => contacts[key])
-			.filter((contact) => contact.parent === folderId)
+			.filter((contact) => contact.parent === parent)
 	);
-
-export const useContactsStoreForTesting = useContactsStore;

--- a/src/legacy/store/contacts.ts
+++ b/src/legacy/store/contacts.ts
@@ -6,6 +6,7 @@
 import produce, { enableMapSet } from 'immer';
 import { create } from 'zustand';
 
+import { Folder } from '../../carbonio-ui-commons/types';
 import { ContactGroup } from '../../model/contact-group';
 import { Contact, ContactOrGroup } from '../types/contact';
 
@@ -91,9 +92,11 @@ export const useContactById = (contactId: string): Contact | undefined =>
 		return undefined;
 	});
 
-export const useContactsByParent = (parent: string): Array<ContactOrGroup> =>
-	useContactsStore(({ contacts, currentFolderViewList }) =>
+export const useContactsByFolder = (folder: Folder): Array<ContactOrGroup> => {
+	const parent = folder.isLink ? `${folder.zid}:${folder.rid}` : folder?.id;
+	return useContactsStore(({ contacts, currentFolderViewList }) =>
 		Array.from(currentFolderViewList)
 			.map((key: string) => contacts[key])
 			.filter((contact) => contact.parent === parent)
 	);
+};

--- a/src/legacy/views/app/contacts-empty-displayer.tsx
+++ b/src/legacy/views/app/contacts-empty-displayer.tsx
@@ -9,12 +9,12 @@ import { Container, Padding, Text } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { useCurrentFolderViewList } from '../../store/contacts';
+import { useContactsByParent } from '../../store/contacts';
 
 export default function ContactsEmptyDisplayer(): React.JSX.Element {
 	const [t] = useTranslation();
 	const { folderId } = useParams<{ folderId: string }>();
-	const contacts = useCurrentFolderViewList(folderId as string);
+	const contacts = useContactsByParent(folderId as string);
 	const trashMessages = useMemo(
 		() => [
 			{

--- a/src/legacy/views/app/contacts-empty-displayer.tsx
+++ b/src/legacy/views/app/contacts-empty-displayer.tsx
@@ -9,12 +9,16 @@ import { Container, Padding, Text } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
 import { useParams } from 'react-router-dom';
 
-import { useContactsByParent } from '../../store/contacts';
+import { useFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
+import { Folder } from '../../../carbonio-ui-commons/types';
+import { useContactsByFolder } from '../../store/contacts';
 
 export default function ContactsEmptyDisplayer(): React.JSX.Element {
 	const [t] = useTranslation();
 	const { folderId } = useParams<{ folderId: string }>();
-	const contacts = useContactsByParent(folderId as string);
+	const folder = useFolder(folderId as string);
+	// TODO: sorry-not-sorry. We should not end up here if there is no folder
+	const contacts = useContactsByFolder(folder as Folder);
 	const trashMessages = useMemo(
 		() => [
 			{

--- a/src/legacy/views/app/folder-panel.tsx
+++ b/src/legacy/views/app/folder-panel.tsx
@@ -14,9 +14,10 @@ import { useParams } from 'react-router-dom';
 import { Breadcrumbs } from './breadcrumbs';
 import { ContactsList } from './folder-panel/contacts-list';
 import { useFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
+import { Folder } from '../../../carbonio-ui-commons/types';
 import { searchContactsHelper } from '../../../views/search-contacts-helper';
 import { useSelection } from '../../hooks/useSelection';
-import { addContactsToStore, setContactsInStore, useContactsByParent } from '../../store/contacts';
+import { addContactsToStore, setContactsInStore, useContactsByFolder } from '../../store/contacts';
 import { isGroup } from '../../utils/helpers';
 import { normalizeContactsFromSoap } from '../../utils/normalizations/normalize-contact-from-soap';
 import { SelectPanelActions } from '../folder/select-panel-actions';
@@ -57,12 +58,7 @@ export const FolderPanel = (): ReactElement => {
 		[]
 	);
 	const [searchResults, setSearchResults] = useState<FolderViewSearchResults>(initialState);
-	const currentFolder = useFolder(folderId);
-	const parent =
-		currentFolder && currentFolder.isLink
-			? `${currentFolder.zid}:${currentFolder.rid}`
-			: currentFolder?.id;
-	const searchContacts = useContactsByParent(parent ?? '');
+	const searchContacts = useContactsByFolder(folder as Folder);
 
 	const sortedContacts = useMemo(
 		() =>

--- a/src/legacy/views/app/folder-panel.tsx
+++ b/src/legacy/views/app/folder-panel.tsx
@@ -16,11 +16,7 @@ import { ContactsList } from './folder-panel/contacts-list';
 import { useFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
 import { searchContactsHelper } from '../../../views/search-contacts-helper';
 import { useSelection } from '../../hooks/useSelection';
-import {
-	addContactsToStore,
-	setContactsInStore,
-	useCurrentFolderViewList
-} from '../../store/contacts';
+import { addContactsToStore, setContactsInStore, useContactsByParent } from '../../store/contacts';
 import { isGroup } from '../../utils/helpers';
 import { normalizeContactsFromSoap } from '../../utils/normalizations/normalize-contact-from-soap';
 import { SelectPanelActions } from '../folder/select-panel-actions';
@@ -61,7 +57,12 @@ export const FolderPanel = (): ReactElement => {
 		[]
 	);
 	const [searchResults, setSearchResults] = useState<FolderViewSearchResults>(initialState);
-	const searchContacts = useCurrentFolderViewList(folderId ?? '');
+	const currentFolder = useFolder(folderId);
+	const parent =
+		currentFolder && currentFolder.isLink
+			? `${currentFolder.zid}:${currentFolder.rid}`
+			: currentFolder?.id;
+	const searchContacts = useContactsByParent(parent ?? '');
 
 	const sortedContacts = useMemo(
 		() =>

--- a/src/legacy/views/app/tests/folder-panel.test.tsx
+++ b/src/legacy/views/app/tests/folder-panel.test.tsx
@@ -49,7 +49,7 @@ import {
 } from '../../../../tests/msw-handlers/find-contact-groups';
 import { createSoapContact, createSoapContactGroup } from '../../../../tests/utils';
 import { FolderPanel } from '../folder-panel';
-import { createContactsApiInterceptor, findContactListItem } from './utils';
+import { createContactsApiInterceptor, findContactInList } from './utils';
 import { SearchContactsRequest, SearchContactsSoapResponse } from '../../../../types';
 import { SoapContact } from '../../../types/soap';
 
@@ -147,7 +147,7 @@ describe('Folder panel', () => {
 				initialEntries: [`/folder/${folder.id}`],
 				path: `/folder/:folderId/:type?/:itemId?`
 			});
-			await findContactListItem(soapContact);
+			await findContactInList(soapContact);
 			expect(screen.getByText(email)).toBeVisible();
 			await firstSearchInterceptor;
 		});
@@ -360,7 +360,7 @@ describe('Folder panel', () => {
 							initialEntries: [`/folder/${folder.id}`],
 							path: `/folder/:folderId/:type?/:itemId?`
 						});
-						await findContactListItem(soapContact);
+						await findContactInList(soapContact);
 
 						const listItem = screen.getByText(email);
 						await act(() => user.hover(listItem));
@@ -426,7 +426,7 @@ describe('Folder panel', () => {
 							initialEntries: [`/folder/${folder.id}`],
 							path: `/folder/:folderId/:type?/:itemId?`
 						});
-						await findContactListItem(soapContact);
+						await findContactInList(soapContact);
 
 						const listItem = screen.getByText(email);
 						await act(() => user.rightClick(listItem));
@@ -459,7 +459,7 @@ describe('Folder panel', () => {
 						initialEntries: [`/folder/${contactsFolder.id}`],
 						path: `/folder/:folderId/:type?/:itemId?`
 					});
-					await findContactListItem(soapContact);
+					await findContactInList(soapContact);
 					const contactListItem = await screen.findByTestId(`contact-list-item-${soapContact.id}`);
 					expect(contactListItem).toBeVisible();
 					const contactListItemName = within(contactListItem).getByText(email);
@@ -504,7 +504,7 @@ describe('Folder panel', () => {
 						initialEntries: [`/folder/${folder.id}`],
 						path: `/folder/:folderId/:type?/:itemId?`
 					});
-					await findContactListItem(soapContact1);
+					await findContactInList(soapContact1);
 
 					// Select all the items
 					const listItems = screen.getAllByTestId(TESTID_SELECTORS.contactsListItem);
@@ -553,7 +553,7 @@ describe('Folder panel', () => {
 								initialEntries: [`/folder/${folder.id}`],
 								path: `/folder/:folderId/:type?/:itemId?`
 							});
-							await findContactListItem(soapContact1);
+							await findContactInList(soapContact1);
 							makeListItemsVisible();
 
 							// Select all the items

--- a/src/legacy/views/app/tests/folder-view.test.tsx
+++ b/src/legacy/views/app/tests/folder-view.test.tsx
@@ -41,7 +41,8 @@ import {
 	createSoapContactGroupV2
 } from '../../../../tests/utils';
 import { FolderView } from '../folder-view';
-import { createContactsApiInterceptor, findContactListItem } from './utils';
+import { createContactsApiInterceptor, findContactInList } from './utils';
+import { generateLinkFolder } from '../../../../views/contact-groups/tests/utils';
 
 jest.mock('../../../../carbonio-ui-commons/integrations/search/use-run-search', () => ({
 	useRunSearchIntegration: jest.fn()
@@ -197,211 +198,242 @@ describe('folder-view', () => {
 	});
 
 	describe('Contacts', () => {
-		const folder = FOLDERS_DESCRIPTORS.contacts;
-		const email = 'test@test.com';
-		const contact = createSoapContact({ id: '10', folderId: folder.id, email });
-		beforeEach(() => {
-			populateFoldersStore();
-			const firstSearchInterceptor = createContactsApiInterceptor({
-				items: [contact],
-				more: false
-			});
-		});
-		it('should delete a contact (move to trash)', async () => {
-			populateFoldersStore();
+		describe('in a folder shared with me', () => {
+			it('should be visible', async () => {
+				const folderId = '100';
+				const remoteAccountUuId = faker.string.uuid();
+				const remoteFolderId = '789';
+				const sharedFolder = generateLinkFolder({
+					folderId,
+					remoteAccountUuId,
+					remoteId: remoteFolderId
+				});
+				useFolderStore.setState({
+					folders: { [folderId]: sharedFolder }
+				});
+				const contactEmail = 'contactInSharedFolder@test.com';
+				const contact = createSoapContact({
+					id: `${remoteAccountUuId}:1`,
+					folderId: `${remoteAccountUuId}:${remoteFolderId}`,
+					email: contactEmail
+				});
+				const searchContacts = createContactsApiInterceptor({
+					items: [contact]
+				});
 
-			const deleteContactInterceptor = createSoapAPIInterceptor<
-				ContactActionRequest,
-				ContactActionResponse
-			>('ContactAction', {
-				_jsns: 'urn:zimbraMail',
-				requestId: '123-456',
-				action: {
-					id: contact.id,
-					op: 'delete'
-				}
-			});
-			const { user } = setupFolderView(
-				folder.id,
-				`/folder/${folder.id}`,
-				`/folder/${folder.id}/contacts/${contact.id}`
-			);
+				setupFolderView(folderId);
 
-			await findContactListItem(contact);
-
-			const displayer = await screen.findByTestId('contact-displayer');
-			expect(displayer).toBeVisible();
-			const deleteContactInDisplayer = await within(displayer).findByTestId(
-				TESTID_SELECTORS.icons.trash
-			);
-			await act(() => user.click(deleteContactInDisplayer));
-			const deleteContactRequest = await deleteContactInterceptor;
-			expect(deleteContactRequest).toEqual({
-				action: {
-					id: contact.id,
-					op: 'trash'
-				}
+				await findContactInList(contact);
+				expect(screen.getByText(contactEmail)).toBeVisible();
 			});
 		});
 
-		it('should call contactsMoveAction when move action is confirmed (displayer)', async () => {
-			const anotherFolder = generateFolder({
-				parent: FOLDERS.USER_ROOT,
-				name: 'anotherContactFolder',
-				id: '500',
-				absFolderPath: '/anotherContactFolder',
-				view: FOLDER_VIEW.contact,
-				children: []
+		describe('in Contacts folder', () => {
+			const folder = FOLDERS_DESCRIPTORS.contacts;
+			const email = 'test@test.com';
+			const contact = createSoapContact({ id: '10', folderId: folder.id, email });
+			beforeEach(() => {
+				populateFoldersStore();
+				const searchInContactsFolderInterceptor = createContactsApiInterceptor({
+					items: [contact],
+					more: false
+				});
 			});
-			populateFoldersStore({
-				customFolders: [anotherFolder]
-			});
+			it('should delete a contact (move to trash)', async () => {
+				populateFoldersStore();
 
-			const { user } = setupFolderView(
-				folder.id,
-				`/folder/${folder.id}`,
-				`/folder/${folder.id}/contacts/${contact.id}`
-			);
+				const deleteContactInterceptor = createSoapAPIInterceptor<
+					ContactActionRequest,
+					ContactActionResponse
+				>('ContactAction', {
+					_jsns: 'urn:zimbraMail',
+					requestId: '123-456',
+					action: {
+						id: contact.id,
+						op: 'delete'
+					}
+				});
+				const { user } = setupFolderView(
+					folder.id,
+					`/folder/${folder.id}`,
+					`/folder/${folder.id}/contacts/${contact.id}`
+				);
 
-			await findContactListItem(contact);
-			const displayer = await screen.findByTestId('contact-displayer');
-			expect(displayer).toBeVisible();
-			const moveButtonInDisplayer = await within(displayer).findByTestId('icon: MoveOutline');
-			await act(() => user.click(moveButtonInDisplayer));
+				await findContactInList(contact);
 
-			act(() => {
-				jest.advanceTimersByTime(1000);
-			});
-
-			const modal = screen.getByTestId('modal');
-			expect(modal).toBeVisible();
-			makeListItemsVisible();
-			await user.click(screen.getByTestId(`folder-accordion-item-${anotherFolder.id}`));
-
-			const contactActionRequestPromise = createSoapAPIInterceptor<
-				ContactActionRequest,
-				ContactActionResponse
-			>('ContactAction', {
-				_jsns: 'urn:zimbraMail',
-				action: { id: contact.id, op: 'move' },
-				requestId: '123'
-			});
-
-			const moveButton = within(modal).getByRole('button', { name: /move/i });
-			expect(moveButton).toBeEnabled();
-			await act(() => user.click(moveButton));
-
-			const contactActionRequest = await contactActionRequestPromise;
-			expect(contactActionRequest).toEqual({
-				action: {
-					id: contact.id,
-					op: 'move',
-					l: anotherFolder.id
-				}
-			});
-		});
-
-		it('should call SendMailAction when Mail icon is clicked in the displayer', async () => {
-			const mailTo = { id: 'mail-to', label: 'action.send_msg', execute: jest.fn() };
-			jest.spyOn(shell, 'getAction').mockReturnValueOnce([mailTo, true]);
-
-			const { user } = setupFolderView(
-				folder.id,
-				`/folder/${folder.id}`,
-				`/folder/${folder.id}/contacts/${contact.id}`
-			);
-
-			await findContactListItem(contact);
-
-			const displayer = await screen.findByTestId('contact-displayer');
-			expect(displayer).toBeVisible();
-			const mailButtonInDisplayer = await within(displayer).findByTestId('icon: MailModOutline');
-			await act(() => user.click(mailButtonInDisplayer));
-
-			expect(mailTo.execute).toHaveBeenCalledWith(
-				expect.objectContaining({
-					id: contact.id
-				})
-			);
-		});
-
-		it('should call search when tag icon is clicked in the displayer', async () => {
-			const runSearch = jest.fn();
-			(useRunSearchIntegration as jest.Mock).mockReturnValue(runSearch);
-
-			const soapContact = createSoapContact({ t: '1', tn: '1', folderId: folder.id });
-			const firstSearchInterceptor = createContactsApiInterceptor({
-				items: [soapContact],
-				more: false
-			});
-			useTagStore.setState({ tags: { '1': { id: '1', name: 'testTag' } } });
-
-			const { user } = setupFolderView(
-				folder.id,
-				`/folder/${folder.id}`,
-				`/folder/${folder.id}/contacts/${soapContact.id}`
-			);
-
-			await findContactListItem(soapContact);
-
-			const displayer = await screen.findByTestId('contact-displayer');
-			expect(displayer).toBeVisible();
-			const tagButtonInDisplayer = await within(displayer).findByTestId('TagIconButton');
-			await user.click(tagButtonInDisplayer);
-
-			expect(runSearch).toHaveBeenCalledWith(
-				[expect.objectContaining({ label: 'tag:testTag', value: 'tag:"testTag"' })],
-				'contacts'
-			);
-		});
-
-		it('should call search when selecting a tag icon inside multitag icon button is clicked in the displayer', async () => {
-			const runSearch = jest.fn();
-			(useRunSearchIntegration as jest.Mock).mockReturnValue(runSearch);
-			const soapContact = createSoapContact({ t: '1,2', tn: '1,2', folderId: folder.id });
-			const firstSearchInterceptor = createContactsApiInterceptor({
-				items: [soapContact],
-				more: false
+				const displayer = await screen.findByTestId('contact-displayer');
+				expect(displayer).toBeVisible();
+				const deleteContactInDisplayer = await within(displayer).findByTestId(
+					TESTID_SELECTORS.icons.trash
+				);
+				await act(() => user.click(deleteContactInDisplayer));
+				const deleteContactRequest = await deleteContactInterceptor;
+				expect(deleteContactRequest).toEqual({
+					action: {
+						id: contact.id,
+						op: 'trash'
+					}
+				});
 			});
 
-			useTagStore.setState({
-				tags: { '1': { id: '1', name: 'testTag1' }, '2': { id: '2', name: 'testTag2' } }
+			it('should call contactsMoveAction when move action is confirmed (displayer)', async () => {
+				const anotherFolder = generateFolder({
+					parent: FOLDERS.USER_ROOT,
+					name: 'anotherContactFolder',
+					id: '500',
+					absFolderPath: '/anotherContactFolder',
+					view: FOLDER_VIEW.contact,
+					children: []
+				});
+				populateFoldersStore({
+					customFolders: [anotherFolder]
+				});
+
+				const { user } = setupFolderView(
+					folder.id,
+					`/folder/${folder.id}`,
+					`/folder/${folder.id}/contacts/${contact.id}`
+				);
+
+				await findContactInList(contact);
+				const displayer = await screen.findByTestId('contact-displayer');
+				expect(displayer).toBeVisible();
+				const moveButtonInDisplayer = await within(displayer).findByTestId('icon: MoveOutline');
+				await act(() => user.click(moveButtonInDisplayer));
+
+				act(() => {
+					jest.advanceTimersByTime(1000);
+				});
+
+				const modal = screen.getByTestId('modal');
+				expect(modal).toBeVisible();
+				makeListItemsVisible();
+				await user.click(screen.getByTestId(`folder-accordion-item-${anotherFolder.id}`));
+
+				const contactActionRequestPromise = createSoapAPIInterceptor<
+					ContactActionRequest,
+					ContactActionResponse
+				>('ContactAction', {
+					_jsns: 'urn:zimbraMail',
+					action: { id: contact.id, op: 'move' },
+					requestId: '123'
+				});
+
+				const moveButton = within(modal).getByRole('button', { name: /move/i });
+				expect(moveButton).toBeEnabled();
+				await act(() => user.click(moveButton));
+
+				const contactActionRequest = await contactActionRequestPromise;
+				expect(contactActionRequest).toEqual({
+					action: {
+						id: contact.id,
+						op: 'move',
+						l: anotherFolder.id
+					}
+				});
 			});
 
-			const { user } = setupFolderView(
-				folder.id,
-				`/folder/${folder.id}`,
-				`/folder/${folder.id}/contacts/${soapContact.id}`
-			);
+			it('should call SendMailAction when Mail icon is clicked in the displayer', async () => {
+				const mailTo = { id: 'mail-to', label: 'action.send_msg', execute: jest.fn() };
+				jest.spyOn(shell, 'getAction').mockReturnValueOnce([mailTo, true]);
 
-			await findContactListItem(soapContact);
-			const displayer = await screen.findByTestId('contact-displayer');
-			expect(displayer).toBeVisible();
-			const tagButtonInDisplayer = await within(displayer).findByTestId('TagIconButton');
-			await user.click(tagButtonInDisplayer);
+				const { user } = setupFolderView(
+					folder.id,
+					`/folder/${folder.id}`,
+					`/folder/${folder.id}/contacts/${contact.id}`
+				);
 
-			const tagsDropdown = await screen.findByTestId('dropdown-popper-list');
+				await findContactInList(contact);
 
-			const testTag1 = within(tagsDropdown).getByText('testTag1');
-			await user.click(testTag1);
-			expect(runSearch).toHaveBeenCalledWith(
-				[expect.objectContaining({ label: 'tag:testTag1', value: 'tag:"testTag1"' })],
-				'contacts'
-			);
+				const displayer = await screen.findByTestId('contact-displayer');
+				expect(displayer).toBeVisible();
+				const mailButtonInDisplayer = await within(displayer).findByTestId('icon: MailModOutline');
+				await act(() => user.click(mailButtonInDisplayer));
 
-			await user.click(tagButtonInDisplayer);
-			const tagsDropdown2 = await screen.findByTestId('dropdown-popper-list');
+				expect(mailTo.execute).toHaveBeenCalledWith(
+					expect.objectContaining({
+						id: contact.id
+					})
+				);
+			});
 
-			const testTag2 = within(tagsDropdown2).getByText('testTag2');
-			await user.click(testTag2);
-			expect(runSearch).toHaveBeenCalledWith(
-				[expect.objectContaining({ label: 'tag:testTag2', value: 'tag:"testTag2"' })],
-				'contacts'
-			);
+			it('should call search when tag icon is clicked in the displayer', async () => {
+				const runSearch = jest.fn();
+				(useRunSearchIntegration as jest.Mock).mockReturnValue(runSearch);
+
+				const soapContact = createSoapContact({ t: '1', tn: '1', folderId: folder.id });
+				const firstSearchInterceptor = createContactsApiInterceptor({
+					items: [soapContact],
+					more: false
+				});
+				useTagStore.setState({ tags: { '1': { id: '1', name: 'testTag' } } });
+
+				const { user } = setupFolderView(
+					folder.id,
+					`/folder/${folder.id}`,
+					`/folder/${folder.id}/contacts/${soapContact.id}`
+				);
+
+				await findContactInList(soapContact);
+
+				const displayer = await screen.findByTestId('contact-displayer');
+				expect(displayer).toBeVisible();
+				const tagButtonInDisplayer = await within(displayer).findByTestId('TagIconButton');
+				await user.click(tagButtonInDisplayer);
+
+				expect(runSearch).toHaveBeenCalledWith(
+					[expect.objectContaining({ label: 'tag:testTag', value: 'tag:"testTag"' })],
+					'contacts'
+				);
+			});
+
+			it('should call search when selecting a tag icon inside multitag icon button is clicked in the displayer', async () => {
+				const runSearch = jest.fn();
+				(useRunSearchIntegration as jest.Mock).mockReturnValue(runSearch);
+				const soapContact = createSoapContact({ t: '1,2', tn: '1,2', folderId: folder.id });
+				const firstSearchInterceptor = createContactsApiInterceptor({
+					items: [soapContact],
+					more: false
+				});
+
+				useTagStore.setState({
+					tags: { '1': { id: '1', name: 'testTag1' }, '2': { id: '2', name: 'testTag2' } }
+				});
+
+				const { user } = setupFolderView(
+					folder.id,
+					`/folder/${folder.id}`,
+					`/folder/${folder.id}/contacts/${soapContact.id}`
+				);
+
+				await findContactInList(soapContact);
+				const displayer = await screen.findByTestId('contact-displayer');
+				expect(displayer).toBeVisible();
+				const tagButtonInDisplayer = await within(displayer).findByTestId('TagIconButton');
+				await user.click(tagButtonInDisplayer);
+
+				const tagsDropdown = await screen.findByTestId('dropdown-popper-list');
+
+				const testTag1 = within(tagsDropdown).getByText('testTag1');
+				await user.click(testTag1);
+				expect(runSearch).toHaveBeenCalledWith(
+					[expect.objectContaining({ label: 'tag:testTag1', value: 'tag:"testTag1"' })],
+					'contacts'
+				);
+
+				await user.click(tagButtonInDisplayer);
+				const tagsDropdown2 = await screen.findByTestId('dropdown-popper-list');
+
+				const testTag2 = within(tagsDropdown2).getByText('testTag2');
+				await user.click(testTag2);
+				expect(runSearch).toHaveBeenCalledWith(
+					[expect.objectContaining({ label: 'tag:testTag2', value: 'tag:"testTag2"' })],
+					'contacts'
+				);
+			});
 		});
 	});
 
-	// This test is a bit messy and complex
 	it('should reload contacts when switching back to initial folder after changing the filter type', async () => {
 		useAppContext.mockReturnValue({ count: 0, setCount: jest.fn() });
 

--- a/src/legacy/views/app/tests/folder-view.test.tsx
+++ b/src/legacy/views/app/tests/folder-view.test.tsx
@@ -198,6 +198,35 @@ describe('folder-view', () => {
 	});
 
 	describe('Contacts', () => {
+		describe('in a shared account folder', () => {
+			it('should be visible', async () => {
+				const remoteAccountUuId = faker.string.uuid();
+				const remoteFolderId = '789';
+				const folderId = `${remoteAccountUuId}:${remoteFolderId}`;
+				const sharedFolder = generateLinkFolder({
+					folderId,
+					remoteAccountUuId,
+					remoteId: remoteFolderId
+				});
+				useFolderStore.setState({
+					folders: { [folderId]: sharedFolder }
+				});
+				const contactEmail = 'contactofSharedAccount@test.com';
+				const contact = createSoapContact({
+					id: `${remoteAccountUuId}:1`,
+					folderId,
+					email: contactEmail
+				});
+				const searchContacts = createContactsApiInterceptor({
+					items: [contact]
+				});
+
+				setupFolderView(folderId);
+
+				await findContactInList(contact);
+				expect(screen.getByText(contactEmail)).toBeVisible();
+			});
+		});
 		describe('in a folder shared with me', () => {
 			it('should be visible', async () => {
 				const folderId = '100';

--- a/src/legacy/views/app/tests/folder-view.test.tsx
+++ b/src/legacy/views/app/tests/folder-view.test.tsx
@@ -97,7 +97,7 @@ describe('folder-view', () => {
 				findContactGroupsResponse: createFindContactGroupsResponse([]),
 				offset: 0
 			});
-			setupFolderView('1');
+			setupFolderView(folderId);
 
 			expect(await screen.findByText(NO_CONTACT_MESSAGE)).toBeVisible();
 		});

--- a/src/legacy/views/app/tests/utils.ts
+++ b/src/legacy/views/app/tests/utils.ts
@@ -24,7 +24,7 @@ export function createContactsApiInterceptor({
 	});
 }
 
-export const findContactListItem = async (contact: SoapContact): Promise<void> => {
+export const findContactInList = async (contact: SoapContact): Promise<void> => {
 	await screen.findByTestId(`custom-contact-list-item-${contact.id}`);
 	makeListItemsVisible();
 };

--- a/src/views/contact-groups/displayer/contact-group-displayer-wrapper.test.tsx
+++ b/src/views/contact-groups/displayer/contact-group-displayer-wrapper.test.tsx
@@ -7,6 +7,7 @@
 import React from 'react';
 
 import { ContactGroupDisplayerWrapper } from './contact-group-displayer-wrapper';
+import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/store/folders';
 import { screen, setupTest, within } from '../../../carbonio-ui-commons/test/test-setup';
 import { EMPTY_DISPLAYER_WITH_CONTACTS_HINT, TESTID_SELECTORS } from '../../../constants/tests';
 import { addContactsToStore } from '../../../legacy/store/contacts';
@@ -17,8 +18,8 @@ describe('Contact groups displayer wrapper', () => {
 	const contactGroup = buildContactGroup();
 	const { parent, id } = contactGroup;
 
-	// TODO: check this test as the empty displayer message does not make any sense
 	it('should show empty displayer if no contact group is active but there are contacts groups in the store', async () => {
+		populateFoldersStore();
 		setupTest(<ContactGroupDisplayerWrapper />, {
 			initialEntries: [`/folder/${parent}`],
 			path: `/folder/:folderId/:type?/:id?`


### PR DESCRIPTION
# Issue
I noticed, from the API response, the "l" parameter (folderID, see: https://docs.zextras.com/apidoc/api-reference/index.html Search API), returns the zid:rid, where zid is the accountUuid and rid the remoteId of the item in case of shared folders (both shared account folders and shared with me).

Since the folderId we receive in the component is the local account folder/link (e.g.: id: 789), and the parent of the contact is zid:rid (e.g.: 0000-1111-2222-3333:123), the results are not shown.

# Solution
Decided to change the hook useContactsByFolder and make it accept a Folder.
This way I am able to understand if the folder is a link and determine the correct value to use (folderId or other in case of Link).

# Tests
Added two tests based on real data received from backend:
- test folder shared with me (folderId in form: '123')
- test folder in shared account (folderId in form: 'uuid:123')
- refactored test utility function name (findContactInList)

Tested also manually that in case of shared account and shared folder contacts are visible.
**Tested also regression (use only folderId in useContactsByFolder)**

