### PR TITLE
fix: [CO-2082] contacts displays "e is undefined"

### DIFF
--- a/src/constants/tests.ts
+++ b/src/constants/tests.ts
@@ -330,8 +330,6 @@ export const TIMERS = {
 
 export const JEST_MOCKED_ERROR = 'jest mocked error';
 export const EMPTY_DISPLAYER_NO_CONTACTS_HINT = 'Stay in touch with your colleagues.';
-export const EMPTY_DISPLAYER_WITH_CONTACTS_HINT =
-	'Create a new contact by clicking the “NEW” button.';
 export const EMPTY_LIST_HINT = 'It looks like there are no contacts yet';
 
 export const EMPTY_DISTRIBUTION_LIST_HINT = 'There are no distribution lists yet.';

--- a/src/legacy/views/app/contacts-empty-displayer.tsx
+++ b/src/legacy/views/app/contacts-empty-displayer.tsx
@@ -7,38 +7,9 @@ import React, { useMemo } from 'react';
 
 import { Container, Padding, Text } from '@zextras/carbonio-design-system';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
-
-import { useFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
-import { Folder } from '../../../carbonio-ui-commons/types';
-import { useContactsByFolder } from '../../store/contacts';
 
 export default function ContactsEmptyDisplayer(): React.JSX.Element {
 	const [t] = useTranslation();
-	const { folderId } = useParams<{ folderId: string }>();
-	const folder = useFolder(folderId as string);
-	// TODO: sorry-not-sorry. We should not end up here if there is no folder
-	const contacts = useContactsByFolder(folder as Folder);
-	const trashMessages = useMemo(
-		() => [
-			{
-				title: t(`displayer.title9`, 'Click the trash icon to delete a contact.'),
-				description: ''
-			},
-			{
-				title: t(`displayer.title10`, 'Select and restore contacts from the trash'),
-				description: ''
-			}
-		],
-		[t]
-	);
-	const emptyListMessage = useMemo(
-		() => ({
-			title: t(`displayer.title1`, 'Create a new contact by clicking the “NEW” button.'),
-			description: ''
-		}),
-		[t]
-	);
 	const emptyFieldMessage = useMemo(
 		() => ({
 			title: t(`displayer.title5`, 'Select a contact'),
@@ -50,15 +21,6 @@ export default function ContactsEmptyDisplayer(): React.JSX.Element {
 		[t]
 	);
 
-	const folderHasAtLeastOneContact = contacts.length > 0;
-	const displayerMessage = useMemo(() => {
-		if (folderId === '3') {
-			return folderHasAtLeastOneContact ? trashMessages[1] : trashMessages[0];
-		}
-		return folderHasAtLeastOneContact ? emptyFieldMessage : emptyListMessage;
-	}, [folderId, folderHasAtLeastOneContact, emptyFieldMessage, emptyListMessage, trashMessages]);
-	const displayerTitle = displayerMessage ? displayerMessage.title : '';
-	const displayerDescription = displayerMessage ? displayerMessage.description : '';
 	return (
 		<Container background="gray5">
 			<Padding all="medium">
@@ -69,7 +31,7 @@ export default function ContactsEmptyDisplayer(): React.JSX.Element {
 					size="large"
 					style={{ whiteSpace: 'pre-line', textAlign: 'center' }}
 				>
-					{displayerTitle}
+					{emptyFieldMessage.title}
 				</Text>
 			</Padding>
 			<Text
@@ -78,7 +40,7 @@ export default function ContactsEmptyDisplayer(): React.JSX.Element {
 				overflow="break-word"
 				style={{ whiteSpace: 'pre-line', textAlign: 'center' }}
 			>
-				{displayerDescription}
+				{emptyFieldMessage.description}
 			</Text>
 		</Container>
 	);

--- a/src/legacy/views/app/folder-list-panel.tsx
+++ b/src/legacy/views/app/folder-list-panel.tsx
@@ -8,7 +8,7 @@ import React, { Suspense } from 'react';
 import { Container } from '@zextras/carbonio-design-system';
 import { Route, Routes } from 'react-router-dom';
 
-import { FolderPanel } from './folder-panel';
+import { FolderPanelWrapper } from './folder-panel-wrapper';
 import { Spinner } from '../../../components/Spinner';
 
 export const FolderListPanel = (): React.JSX.Element => (
@@ -18,7 +18,7 @@ export const FolderListPanel = (): React.JSX.Element => (
 			element={
 				<Container width="40%" borderColor={{ right: 'gray3' }}>
 					<Suspense fallback={<Spinner />}>
-						<FolderPanel />
+						<FolderPanelWrapper />
 					</Suspense>
 				</Container>
 			}

--- a/src/legacy/views/app/folder-panel-wrapper.tsx
+++ b/src/legacy/views/app/folder-panel-wrapper.tsx
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+import React from 'react';
+
+import { useParams } from 'react-router-dom';
+
+import { FolderPanel } from './folder-panel';
+import { useFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
+import { RouteParams } from '../../../constants';
+
+export const FolderPanelWrapper = (): React.JSX.Element => {
+	const { folderId } = useParams<RouteParams>() as { folderId: string };
+	const folder = useFolder(folderId);
+	if (folder) {
+		return <FolderPanel folder={folder} />;
+	}
+	return <></>;
+};

--- a/src/legacy/views/app/folder-panel-wrapper.tsx
+++ b/src/legacy/views/app/folder-panel-wrapper.tsx
@@ -14,8 +14,6 @@ import { RouteParams } from '../../../constants';
 export const FolderPanelWrapper = (): React.JSX.Element => {
 	const { folderId } = useParams<RouteParams>() as { folderId: string };
 	const folder = useFolder(folderId);
-	if (folder) {
-		return <FolderPanel folder={folder} />;
-	}
-	return <></>;
+	if (!folder) return <></>;
+	return <FolderPanel folder={folder} />;
 };

--- a/src/legacy/views/app/folder-panel.tsx
+++ b/src/legacy/views/app/folder-panel.tsx
@@ -21,10 +21,6 @@ import { normalizeContactsFromSoap } from '../../utils/normalizations/normalize-
 import { SelectPanelActions } from '../folder/select-panel-actions';
 import { FolderViewSearchResults } from '../search/types';
 
-type RouteParams = {
-	folderId: string;
-};
-
 type UseAppContextType = {
 	setCount: (count: number) => void;
 };
@@ -173,7 +169,7 @@ export const FolderPanel = ({ folder }: FolderPanelProps): ReactElement => {
 			<Container mainAlignment="flex-start" borderRadius="none">
 				{isSelecting ? (
 					<SelectPanelActions
-						folderId={folder.id ?? ''}
+						folderId={folder.id}
 						deselectAll={deselectAll}
 						selectedContacts={selectedContacts}
 						selectedIds={selected}
@@ -201,7 +197,7 @@ export const FolderPanel = ({ folder }: FolderPanelProps): ReactElement => {
 				)}
 				<ContactsList
 					onListBottom={loadMore}
-					folderId={folder.id ?? ''}
+					folderId={folder.id}
 					contacts={sortedContacts}
 					selected={selected}
 					isSelecting={isSelecting}

--- a/src/legacy/views/app/folder-panel.tsx
+++ b/src/legacy/views/app/folder-panel.tsx
@@ -9,11 +9,9 @@ import { Container, MultiButton, Row, Tooltip } from '@zextras/carbonio-design-s
 import { useAppContext } from '@zextras/carbonio-shell-ui';
 import { filter, find, noop, orderBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
 
 import { Breadcrumbs } from './breadcrumbs';
 import { ContactsList } from './folder-panel/contacts-list';
-import { useFolder } from '../../../carbonio-ui-commons/store/zustand/folder';
 import { Folder } from '../../../carbonio-ui-commons/types';
 import { searchContactsHelper } from '../../../views/search-contacts-helper';
 import { useSelection } from '../../hooks/useSelection';
@@ -38,14 +36,14 @@ const FILTER_TYPES = {
 } as const;
 
 type ContactFilterType = (typeof FILTER_TYPES)[keyof typeof FILTER_TYPES];
-
-export const FolderPanel = (): ReactElement => {
+type FolderPanelProps = {
+	folder: Folder;
+};
+export const FolderPanel = ({ folder }: FolderPanelProps): ReactElement => {
 	const [t] = useTranslation();
-	const { folderId } = useParams<RouteParams>() as { folderId: string };
-	const folder = useFolder(folderId);
 	const { setCount } = useAppContext<UseAppContextType>();
 	const loading = useRef(false);
-	const { selected, isSelecting, toggle, deselectAll } = useSelection(folderId, setCount);
+	const { selected, isSelecting, toggle, deselectAll } = useSelection(folder.id, setCount);
 	const [activeFilter, setActiveFilter] = useState<ContactFilterType>(FILTER_TYPES.ALL);
 
 	const prevQuery = useRef<string>('');
@@ -58,7 +56,7 @@ export const FolderPanel = (): ReactElement => {
 		[]
 	);
 	const [searchResults, setSearchResults] = useState<FolderViewSearchResults>(initialState);
-	const searchContacts = useContactsByFolder(folder as Folder);
+	const searchContacts = useContactsByFolder(folder);
 
 	const sortedContacts = useMemo(
 		() =>
@@ -106,14 +104,14 @@ export const FolderPanel = (): ReactElement => {
 	);
 
 	const query = useMemo((): string => {
-		let queryContent = `inid:"${folderId}"`;
+		let queryContent = `inid:"${folder.id}"`;
 		if (activeFilter === 'CONTACT') {
 			queryContent += ` and not #type:group`;
 		} else if (activeFilter === 'CONTACT_GROUP') {
 			queryContent += ` and #type:group`;
 		}
 		return queryContent;
-	}, [activeFilter, folderId]);
+	}, [activeFilter, folder.id]);
 
 	useEffect(() => {
 		if (query === prevQuery.current) return;
@@ -175,7 +173,7 @@ export const FolderPanel = (): ReactElement => {
 			<Container mainAlignment="flex-start" borderRadius="none">
 				{isSelecting ? (
 					<SelectPanelActions
-						folderId={folderId ?? ''}
+						folderId={folder.id ?? ''}
 						deselectAll={deselectAll}
 						selectedContacts={selectedContacts}
 						selectedIds={selected}
@@ -203,7 +201,7 @@ export const FolderPanel = (): ReactElement => {
 				)}
 				<ContactsList
 					onListBottom={loadMore}
-					folderId={folderId ?? ''}
+					folderId={folder.id ?? ''}
 					contacts={sortedContacts}
 					selected={selected}
 					isSelecting={isSelecting}

--- a/src/legacy/views/app/tests/detail-panel.test.tsx
+++ b/src/legacy/views/app/tests/detail-panel.test.tsx
@@ -9,15 +9,15 @@ import React from 'react';
 import { faker } from '@faker-js/faker';
 import { http, HttpResponse } from 'msw';
 
-import { DetailPanel } from './detail-panel';
-import { FOLDERS } from '../../../carbonio-ui-commons/constants/folders';
-import { getSetupServer } from '../../../carbonio-ui-commons/test/jest-setup';
-import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/store/folders';
-import { screen, setupTest } from '../../../carbonio-ui-commons/test/test-setup';
-import { JEST_MOCKED_ERROR, TESTID_SELECTORS } from '../../../constants/tests';
-import { buildSoapError } from '../../../tests/utils';
-import * as modifyContactApi from '../../store/actions/modify-contact';
-import { addContactsToStore } from '../../store/contacts';
+import { FOLDERS } from '../../../../carbonio-ui-commons/constants/folders';
+import { getSetupServer } from '../../../../carbonio-ui-commons/test/jest-setup';
+import { populateFoldersStore } from '../../../../carbonio-ui-commons/test/mocks/store/folders';
+import { screen, setupTest } from '../../../../carbonio-ui-commons/test/test-setup';
+import { JEST_MOCKED_ERROR, TESTID_SELECTORS } from '../../../../constants/tests';
+import { buildSoapError } from '../../../../tests/utils';
+import * as modifyContactApi from '../../../store/actions/modify-contact';
+import { addContactsToStore } from '../../../store/contacts';
+import { DetailPanel } from '../detail-panel';
 
 describe('Detail panel', () => {
 	describe('Contacts', () => {

--- a/src/legacy/views/app/tests/folder-panel-wrapper.test.tsx
+++ b/src/legacy/views/app/tests/folder-panel-wrapper.test.tsx
@@ -107,6 +107,14 @@ describe('Folder panel', () => {
 		expect(await screen.findByText(EMPTY_LIST_HINT)).toBeVisible();
 	});
 
+	it('should return an empty fragment if folder id is not valid', async () => {
+		const folderId = 'a-non-valid-folder-id';
+
+		const { container } = setupFolderPanel(folderId);
+
+		expect(container).toBeEmptyDOMElement();
+	});
+
 	describe('Pagination', () => {
 		it('should load more results when scrolling bottom of the list', async () => {
 			const folderId = FOLDERS.CONTACTS;

--- a/src/legacy/views/app/tests/folder-panel-wrapper.test.tsx
+++ b/src/legacy/views/app/tests/folder-panel-wrapper.test.tsx
@@ -10,6 +10,7 @@ import { act, fireEvent } from '@testing-library/react';
 import * as shell from '@zextras/carbonio-shell-ui';
 import { forEach } from 'lodash';
 
+import { createContactsApiInterceptor, findContactInList } from './utils';
 import { FOLDER_VIEW } from '../../../../carbonio-ui-commons/constants';
 import { FOLDERS } from '../../../../carbonio-ui-commons/constants/folders';
 import { useTagStore } from '../../../../carbonio-ui-commons/store/zustand/tags';
@@ -48,10 +49,9 @@ import {
 	registerFindContactGroupsHandler
 } from '../../../../tests/msw-handlers/find-contact-groups';
 import { createSoapContact, createSoapContactGroup } from '../../../../tests/utils';
-import { FolderPanel } from '../folder-panel';
-import { createContactsApiInterceptor, findContactInList } from './utils';
 import { SearchContactsRequest, SearchContactsSoapResponse } from '../../../../types';
 import { SoapContact } from '../../../types/soap';
+import { FolderPanelWrapper } from '../folder-panel-wrapper';
 
 const mockMailToAction = (execute = jest.fn()): void => {
 	getActionMock.mockImplementation((type, id) => {
@@ -70,7 +70,7 @@ const mockMailToAction = (execute = jest.fn()): void => {
 };
 
 function setupFolderPanel(folderId: string): ReturnType<typeof setupTest> {
-	return setupTest(<FolderPanel />, {
+	return setupTest(<FolderPanelWrapper />, {
 		initialEntries: [`/folder/${folderId}`],
 		path: 'folder/:folderId/:type?/:itemId?'
 	});
@@ -143,7 +143,7 @@ describe('Folder panel', () => {
 				more: false
 			});
 
-			setupTest(<FolderPanel />, {
+			setupTest(<FolderPanelWrapper />, {
 				initialEntries: [`/folder/${folder.id}`],
 				path: `/folder/:folderId/:type?/:itemId?`
 			});
@@ -356,7 +356,7 @@ describe('Folder panel', () => {
 							more: false
 						});
 
-						const { user } = setupTest(<FolderPanel />, {
+						const { user } = setupTest(<FolderPanelWrapper />, {
 							initialEntries: [`/folder/${folder.id}`],
 							path: `/folder/:folderId/:type?/:itemId?`
 						});
@@ -422,7 +422,7 @@ describe('Folder panel', () => {
 							more: false
 						});
 
-						const { user } = setupTest(<FolderPanel />, {
+						const { user } = setupTest(<FolderPanelWrapper />, {
 							initialEntries: [`/folder/${folder.id}`],
 							path: `/folder/:folderId/:type?/:itemId?`
 						});
@@ -455,7 +455,7 @@ describe('Folder panel', () => {
 					});
 
 					useTagStore.setState({ tags: { '1': { id: '1', name: 'testTag' } } });
-					const { user } = setupTest(<FolderPanel />, {
+					const { user } = setupTest(<FolderPanelWrapper />, {
 						initialEntries: [`/folder/${contactsFolder.id}`],
 						path: `/folder/:folderId/:type?/:itemId?`
 					});
@@ -500,7 +500,7 @@ describe('Folder panel', () => {
 						more: false
 					});
 
-					const { user } = setupTest(<FolderPanel />, {
+					const { user } = setupTest(<FolderPanelWrapper />, {
 						initialEntries: [`/folder/${folder.id}`],
 						path: `/folder/:folderId/:type?/:itemId?`
 					});
@@ -549,7 +549,7 @@ describe('Folder panel', () => {
 							});
 							useAppContext.mockReturnValue({ count: 42, setCount: jest.fn() });
 
-							const { user } = setupTest(<FolderPanel />, {
+							const { user } = setupTest(<FolderPanelWrapper />, {
 								initialEntries: [`/folder/${folder.id}`],
 								path: `/folder/:folderId/:type?/:itemId?`
 							});

--- a/src/views/contact-groups/displayer/contact-group-displayer-wrapper.test.tsx
+++ b/src/views/contact-groups/displayer/contact-group-displayer-wrapper.test.tsx
@@ -9,7 +9,7 @@ import React from 'react';
 import { ContactGroupDisplayerWrapper } from './contact-group-displayer-wrapper';
 import { populateFoldersStore } from '../../../carbonio-ui-commons/test/mocks/store/folders';
 import { screen, setupTest, within } from '../../../carbonio-ui-commons/test/test-setup';
-import { EMPTY_DISPLAYER_WITH_CONTACTS_HINT, TESTID_SELECTORS } from '../../../constants/tests';
+import { TESTID_SELECTORS } from '../../../constants/tests';
 import { addContactsToStore } from '../../../legacy/store/contacts';
 import { buildContactGroup } from '../../../tests/model-builder';
 import { CONTACT_GROUPS_PATH } from '../navigation';
@@ -18,20 +18,22 @@ describe('Contact groups displayer wrapper', () => {
 	const contactGroup = buildContactGroup();
 	const { parent, id } = contactGroup;
 
-	it('should show empty displayer if no contact group is active but there are contacts groups in the store', async () => {
+	it('should display empty displayer if no contact group is active but there are contacts groups in the store', async () => {
 		populateFoldersStore();
 		setupTest(<ContactGroupDisplayerWrapper />, {
 			initialEntries: [`/folder/${parent}`],
 			path: `/folder/:folderId/:type?/:id?`
 		});
-		const emptyDisplayerMessage = await screen.findByText(EMPTY_DISPLAYER_WITH_CONTACTS_HINT);
+		const emptyDisplayerMessage = await screen.findByText(
+			'Discover all the ways you can connect with other users.'
+		);
 		expect(emptyDisplayerMessage).toBeVisible();
 		expect(
 			screen.queryByRoleWithIcon('button', { icon: TESTID_SELECTORS.icons.closeDisplayer })
 		).not.toBeInTheDocument();
 	});
 
-	it('should show contact group details if a contact group is active', () => {
+	it('should display contact group details if a contact group is active', () => {
 		addContactsToStore([contactGroup]);
 		setupTest(<ContactGroupDisplayerWrapper />, {
 			initialEntries: [`/folder/${parent}/${CONTACT_GROUPS_PATH}/${id}`],


### PR DESCRIPTION
Changes:
- add folder-panel-wrapper.tsx to avoid casting folder received from useFolderById
- in case folders are not loaded the folder could be undefined. This wrapper prevents accessing an undefined variable in folder-panel.tsx