### PR TITLE
[CO-2194] UI breaks in search module

### DIFF
--- a/src/legacy/views/search/search-view.tsx
+++ b/src/legacy/views/search/search-view.tsx
@@ -18,6 +18,9 @@ import { map, reduce } from 'lodash';
 import { useTranslation } from 'react-i18next';
 import { Route, Routes } from 'react-router-dom';
 
+import { addContactsToStore, useContactsById } from 'legacy/store/contacts';
+import ContactEditPanel from 'legacy/views/edit/contact-edit-panel';
+import { ContactPreviewWrapper } from 'legacy/views/preview/contact-preview-wrapper';
 import AdvancedFilterModal from 'legacy/views/search/advance-filter-modal';
 import { runSearch } from 'legacy/views/search/run-search';
 import { SearchContactsEmptyPanel } from 'legacy/views/search/search-contacts-empty-panel';
@@ -25,9 +28,6 @@ import { SearchList } from 'legacy/views/search/search-list';
 import { Query } from 'legacy/views/search/search-types';
 import { SearchResults } from 'legacy/views/search/types';
 import { ContactGroupDisplayerWrapper } from 'views/contact-groups/displayer/contact-group-displayer-wrapper';
-import { addContactsToStore, useContactsById } from 'legacy/store/contacts';
-import ContactEditPanel from 'legacy/views/edit/contact-edit-panel';
-import { ContactPreviewWrapper } from 'legacy/views/preview/contact-preview-wrapper';
 
 const specialChars = [
 	'~',
@@ -55,8 +55,9 @@ const specialChars = [
 	'>'
 ];
 
-const containsSpecialCharacters = (value: string): boolean => {
-	const text = value.startsWith('tag:') ? value.substring(4) : value;
+const containsSpecialCharacters = (value: string | boolean): boolean => {
+	const stringValue = typeof value === 'string' ? value : '';
+	const text = stringValue.startsWith('tag:') ? stringValue.substring(4) : stringValue;
 	return specialChars.some((specialChar) => text.includes(specialChar));
 };
 

--- a/src/legacy/views/search/search-view.tsx
+++ b/src/legacy/views/search/search-view.tsx
@@ -55,7 +55,7 @@ const specialChars = [
 	'>'
 ];
 
-const containsSpecialCharacters = (value: string | boolean): boolean => {
+export const containsSpecialCharacters = (value: string | boolean): boolean => {
 	const stringValue = typeof value === 'string' ? value : '';
 	const text = stringValue.startsWith('tag:') ? stringValue.substring(4) : stringValue;
 	return specialChars.some((specialChar) => text.includes(specialChar));

--- a/src/legacy/views/search/tests/contains-special-characters.test.ts
+++ b/src/legacy/views/search/tests/contains-special-characters.test.ts
@@ -1,0 +1,19 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { containsSpecialCharacters } from '../search-view';
+
+describe('containsSpecialCharacters', () => {
+	describe('should handle boolean values', () => {
+		it('should return false for a boolean true input', () => {
+			expect(containsSpecialCharacters(true)).toBe(false);
+		});
+
+		it('should return false for a boolean false input', () => {
+			expect(containsSpecialCharacters(false)).toBe(false);
+		});
+	});
+});

--- a/src/legacy/views/search/tests/search-view.test.tsx
+++ b/src/legacy/views/search/tests/search-view.test.tsx
@@ -15,17 +15,6 @@ import { FOLDERS, useFolderStore } from '@zextras/carbonio-ui-commons';
 import { noop } from 'lodash';
 import { HttpResponse } from 'msw';
 
-import { TIMERS } from 'constants/tests';
-import { CnItem } from 'network/api/types';
-import { createSoapContact, createSoapContactGroupV2 } from 'tests/utils';
-import {
-	SearchContactsRequest,
-	SearchContactsSoapRequest,
-	SearchContactsSoapResponse
-} from 'types';
-import { type SoapContact } from 'legacy/types/soap';
-import { Query } from 'legacy/views/search/search-types';
-import SearchView from 'legacy/views/search/search-view';
 import { makeListItemsVisible, screen, setupTest, triggerLoadMore } from '@test-setup';
 import { generateFolder } from '@test-utils/folders/folders-generator';
 import {
@@ -34,6 +23,17 @@ import {
 } from '@test-utils/network/msw/create-api-interceptor';
 import { generateSettings } from '@test-utils/settings/settings-generator';
 import { populateFoldersStore } from '@test-utils/store/folders';
+import { TIMERS } from 'constants/tests';
+import { type SoapContact } from 'legacy/types/soap';
+import { Query } from 'legacy/views/search/search-types';
+import SearchView from 'legacy/views/search/search-view';
+import { CnItem } from 'network/api/types';
+import { createSoapContact, createSoapContactGroupV2 } from 'tests/utils';
+import {
+	SearchContactsRequest,
+	SearchContactsSoapRequest,
+	SearchContactsSoapResponse
+} from 'types';
 
 const useMockedUseQuery = (): ReturnType<typeof useQuery> => {
 	const queryChip: QueryChip = {


### PR DESCRIPTION
Update the containsSpecialCharacters function to accept both string and boolean types for the value parameter. Ensure that non-string values are safely handled by converting them to an empty string before processing. Adjust internal logic to use the correct variable for extracting text after 'tag:' prefix.