### PR TITLE
feat: [CO-2299] show distribution list display names in autocomplete results

### DIFF
--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -9,7 +9,8 @@ import {
 	parseEmail,
 	CONTACT_TYPES,
 	ContactInputItemInternalValue,
-	GroupContact
+	GroupContact,
+	DistributionListContact
 } from '@zextras/carbonio-ui-commons';
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
 import { map, trim, unescape } from 'lodash';
@@ -42,12 +43,16 @@ export function isContactGroup(contact: {
 export const getContactId = (contact: ContactInputItemInternalValue): string =>
 	contact.type === CONTACT_TYPES.GROUP ? contact.id : contact.email;
 
-export const getContactLabel = (contact: ContactInputItemInternalValue): string => {
+type DistributionListContactWithDisplay = DistributionListContact & { fullName?: string };
+
+export const getContactLabel = (
+	contact: ContactInputItemInternalValue | DistributionListContactWithDisplay
+): string => {
 	switch (contact.type) {
 		case CONTACT_TYPES.GROUP:
 			return contact.display;
 		case CONTACT_TYPES.DISTRIBUTION_LIST:
-			return contact.email;
+			return (contact as DistributionListContactWithDisplay).fullName || contact.email;
 		default:
 			break;
 	}
@@ -89,10 +94,11 @@ export const mapToChipContactOptions = (value: RemoteContactResponse): ContactIn
 	}
 	const parsedEmail = tryToParseEmail(value.email);
 	if (newIsDistributionList(value)) {
-		const distributionList = {
+		const distributionList: DistributionListContactWithDisplay = {
 			id: parsedEmail,
 			email: parsedEmail,
-			type: CONTACT_TYPES.DISTRIBUTION_LIST
+			type: CONTACT_TYPES.DISTRIBUTION_LIST,
+			fullName: value.full
 		};
 		const label = getContactLabel(distributionList);
 		return {

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -52,7 +52,10 @@ export const getContactLabel = (
 		case CONTACT_TYPES.GROUP:
 			return contact.display;
 		case CONTACT_TYPES.DISTRIBUTION_LIST:
-			return (contact as DistributionListContactWithDisplay).fullName || contact.email;
+			if ('fullName' in contact && contact.fullName) {
+				return contact.fullName;
+			}
+			return contact.email;
 		default:
 			break;
 	}

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -45,24 +45,46 @@ export const getContactId = (contact: ContactInputItemInternalValue): string =>
 
 type DistributionListContactWithDisplay = DistributionListContact & { fullName?: string };
 
+function isGroupContact(
+	contact: ContactInputItemInternalValue | DistributionListContactWithDisplay
+): contact is ContactInputItemInternalValue & { type: typeof CONTACT_TYPES.GROUP } {
+	return contact.type === CONTACT_TYPES.GROUP;
+}
+
+function isDistributionListContact(
+	contact: ContactInputItemInternalValue | DistributionListContactWithDisplay
+): contact is DistributionListContactWithDisplay {
+	return contact.type === CONTACT_TYPES.DISTRIBUTION_LIST;
+}
+
+function getGroupLabel(contact: { display: string }): string {
+	return contact.display;
+}
+
+function getDistributionListLabel(contact: { fullName?: string; email: string }): string {
+	return contact.fullName?.trim() ? contact.fullName : contact.email;
+}
+
+function getPersonLabel(contact: {
+	firstName?: string;
+	middleName?: string;
+	lastName?: string;
+	fullName?: string;
+	email: string;
+}): string {
+	const nameParts = [contact.firstName, contact.middleName, contact.lastName].filter(Boolean);
+	if (nameParts.length > 0) {
+		return trim(nameParts.join(' '));
+	}
+	return contact.fullName ?? contact.email;
+}
+
 export const getContactLabel = (
 	contact: ContactInputItemInternalValue | DistributionListContactWithDisplay
 ): string => {
-	switch (contact.type) {
-		case CONTACT_TYPES.GROUP:
-			return contact.display;
-		case CONTACT_TYPES.DISTRIBUTION_LIST:
-			if ('fullName' in contact && contact.fullName) {
-				return contact.fullName;
-			}
-			return contact.email;
-		default:
-			break;
-	}
-	if (contact.firstName ?? contact.middleName ?? contact.lastName) {
-		return trim(`${contact.firstName ?? ''} ${contact.middleName ?? ''} ${contact.lastName ?? ''}`);
-	}
-	return contact.fullName ?? contact.email;
+	if (isGroupContact(contact)) return getGroupLabel(contact);
+	if (isDistributionListContact(contact)) return getDistributionListLabel(contact);
+	return getPersonLabel(contact);
 };
 
 export function tryToParseEmail(input: string | undefined): string {

--- a/src/legacy/integrations/tests/contact-input.test.tsx
+++ b/src/legacy/integrations/tests/contact-input.test.tsx
@@ -382,6 +382,88 @@ describe('Contact input', () => {
 				expect.objectContaining({ actions: [editValidChipAction] })
 			]);
 		});
+
+		it('should show distribution list display name in autocomplete dropdown when full name is provided', async () => {
+			const distributionListDisplayName = 'MyDistributionList One';
+			const distributionListEmail = 'mydist@demo.test.io';
+			const autocompleteInterceptor = createAutocompleteInterceptor([
+				{
+					email: `"${distributionListDisplayName}" <${distributionListEmail}>`,
+					full: distributionListDisplayName,
+					isGroup: true
+				}
+			]);
+
+			const { user } = setupTest(<ContactInput defaultValue={[]} orderedAccountIds={[]} />);
+
+			const input = screen.getByRole('textbox');
+			await user.type(input, distributionListDisplayName);
+			const dropdown = await screen.findByTestId(TESTID_SELECTORS.dropdownList);
+			await autocompleteInterceptor;
+
+			expect(await within(dropdown).findByText(distributionListDisplayName)).toBeVisible();
+		});
+
+		it('should create chip with display name label when distribution list is selected from autocomplete', async () => {
+			const onChange = jest.fn();
+			const distributionListDisplayName = 'Sales Team Distribution';
+			const distributionListEmail = 'sales-team@demo.test.io';
+			const autocompleteInterceptor = createAutocompleteInterceptor([
+				{
+					email: `"${distributionListDisplayName}" <${distributionListEmail}>`,
+					full: distributionListDisplayName,
+					isGroup: true
+				}
+			]);
+
+			const { user } = setupTest(
+				<ContactInput defaultValue={[]} orderedAccountIds={[]} onChange={onChange} />
+			);
+
+			await typeAndSelectOptionFromDropdown(user, distributionListDisplayName);
+			await autocompleteInterceptor;
+
+			expect(onChange).toHaveBeenCalledWith([
+				expect.objectContaining({
+					label: distributionListDisplayName,
+					value: expect.objectContaining({
+						type: CONTACT_TYPES.DISTRIBUTION_LIST,
+						email: distributionListEmail,
+						fullName: distributionListDisplayName
+					})
+				})
+			]);
+		});
+
+		it('should fallback to email as label when distribution list has no display name', async () => {
+			const onChange = jest.fn();
+			const distributionListEmail = 'no-display-name@demo.test.io';
+			const autocompleteInterceptor = createAutocompleteInterceptor([
+				{
+					email: distributionListEmail,
+					full: '',
+					isGroup: true
+				}
+			]);
+
+			const { user } = setupTest(
+				<ContactInput defaultValue={[]} orderedAccountIds={[]} onChange={onChange} />
+			);
+
+			await typeAndSelectOptionFromDropdown(user, distributionListEmail);
+			await autocompleteInterceptor;
+
+			expect(onChange).toHaveBeenCalledWith([
+				expect.objectContaining({
+					label: distributionListEmail,
+					value: expect.objectContaining({
+						type: CONTACT_TYPES.DISTRIBUTION_LIST,
+						email: distributionListEmail
+					})
+				})
+			]);
+		});
+
 		it('should show custom action if provided', async () => {
 			setupTest(
 				<ContactInput

--- a/src/legacy/integrations/tests/utils.test.ts
+++ b/src/legacy/integrations/tests/utils.test.ts
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { CONTACT_TYPES } from '@zextras/carbonio-ui-commons';
+
+import { getContactLabel, mapToChipContactOptions } from 'legacy/integrations/parts/utils';
+import { RemoteDistributionListContact } from 'legacy/integrations/types';
+
+describe('utils', () => {
+	describe('getContactLabel', () => {
+		it('should return display name for distribution list when fullName is provided', () => {
+			const distributionListContact = {
+				id: 'dl@example.com',
+				email: 'dl@example.com',
+				type: CONTACT_TYPES.DISTRIBUTION_LIST,
+				fullName: 'My Distribution List'
+			};
+
+			const label = getContactLabel(distributionListContact);
+
+			expect(label).toBe('My Distribution List');
+		});
+
+		it('should fallback to email for distribution list when fullName is not provided', () => {
+			const distributionListContact = {
+				id: 'dl@example.com',
+				email: 'dl@example.com',
+				type: CONTACT_TYPES.DISTRIBUTION_LIST
+			};
+
+			const label = getContactLabel(distributionListContact);
+
+			expect(label).toBe('dl@example.com');
+		});
+
+		it('should fallback to email for distribution list when fullName is empty', () => {
+			const distributionListContact = {
+				id: 'dl@example.com',
+				email: 'dl@example.com',
+				type: CONTACT_TYPES.DISTRIBUTION_LIST,
+				fullName: ''
+			};
+
+			const label = getContactLabel(distributionListContact);
+
+			expect(label).toBe('dl@example.com');
+		});
+	});
+
+	describe('mapToChipContactOptions', () => {
+		it('should create distribution list option with display name from autocomplete response', () => {
+			const autocompleteResponse: RemoteDistributionListContact = {
+				isGroup: true,
+				email: '"MyDistributionList One" <mydist@demo.zextras.io>',
+				exp: false,
+				full: 'MyDistributionList One',
+				fileas: '8:MyDistributionList One'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			expect(result.label).toBe('MyDistributionList One');
+			expect(result.value).toEqual(
+				expect.objectContaining({
+					type: CONTACT_TYPES.DISTRIBUTION_LIST,
+					fullName: 'MyDistributionList One'
+				})
+			);
+		});
+
+		it('should create distribution list option with parsed email when display name is not available', () => {
+			const autocompleteResponse: RemoteDistributionListContact = {
+				isGroup: true,
+				email: 'mydist@demo.zextras.io',
+				exp: false,
+				full: '',
+				fileas: '8:mydist@demo.zextras.io'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			expect(result.label).toBe('mydist@demo.zextras.io');
+			expect(result.value).toEqual(
+				expect.objectContaining({
+					type: CONTACT_TYPES.DISTRIBUTION_LIST,
+					email: 'mydist@demo.zextras.io',
+					fullName: ''
+				})
+			);
+		});
+
+		it('should handle complex email format with display name', () => {
+			const autocompleteResponse: RemoteDistributionListContact = {
+				isGroup: true,
+				email: '"Sales Team Distribution" <sales-team@company.com>',
+				exp: false,
+				full: 'Sales Team Distribution',
+				fileas: '8:Sales Team Distribution'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			expect(result.label).toBe('Sales Team Distribution');
+			expect(result.value).toEqual(
+				expect.objectContaining({
+					type: CONTACT_TYPES.DISTRIBUTION_LIST,
+					email: 'sales-team@company.com',
+					fullName: 'Sales Team Distribution'
+				})
+			);
+		});
+
+		it('should create distribution list with correct structure including all required properties', () => {
+			const autocompleteResponse: RemoteDistributionListContact = {
+				isGroup: true,
+				email: '"Test DL" <test@example.com>',
+				exp: false,
+				full: 'Test Distribution List',
+				fileas: '8:Test Distribution List'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			expect(result).toEqual({
+				label: 'Test Distribution List',
+				value: expect.objectContaining({
+					id: 'test@example.com',
+					email: 'test@example.com',
+					type: CONTACT_TYPES.DISTRIBUTION_LIST,
+					fullName: 'Test Distribution List'
+				}),
+				id: 'test@example.com',
+				customComponent: expect.any(Object)
+			});
+		});
+	});
+});


### PR DESCRIPTION
This PR adds support for displaying distribution list display names in autocomplete results, improving user experience by showing meaningful names instead of email addresses when available.

- Modified `getContactLabel` function to return distribution list display names when available
- Updated `mapToChipContactOptions` to include the `fullName` property for distribution lists
- Minor refactor for improved readability and maintenance 
- Added comprehensive test coverage for the new functionality