### PR TITLE
feat: [CO-2298] Show Contact display name as ContactInput Chip label 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-	identifier: 'zapp-jenkins-lib@github-pipeline-v4',
-	retriever: modernSCM([
-		$class: 'GitSCMSource',
-		remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
-		credentialsId: 'jenkins-integration-with-github-account'
-	])
+    identifier: 'zapp-jenkins-lib@chore/IN-930-streamline-pipeline',
+    retriever: modernSCM([
+        $class: 'GitSCMSource',
+        remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
+        credentialsId: 'jenkins-integration-with-github-account'
+    ])
 )
 
 zappPipeline(disableAutoTranslationsSync: true)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'zapp-jenkins-lib@chore/IN-930-streamline-pipeline',
+    identifier: 'zapp-jenkins-lib@github-pipeline-v4',
     retriever: modernSCM([
-        $class: 'GitSCMSource',
-        remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
-        credentialsId: 'jenkins-integration-with-github-account'
+      $class: 'GitSCMSource',
+      remote: 'git@github.com:zextras/jenkins-zapp-lib.git',
+      credentialsId: 'jenkins-integration-with-github-account'
     ])
 )
 

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -13,7 +13,7 @@ import {
 	DistributionListContact
 } from '@zextras/carbonio-ui-commons';
 import { legacySoapFetch } from '@zextras/carbonio-ui-soap-lib';
-import { map, trim, unescape } from 'lodash';
+import { map, unescape } from 'lodash';
 
 import { Hint } from 'legacy/integrations/parts/hint';
 import { HintGroup } from 'legacy/integrations/parts/hint-group';
@@ -65,26 +65,66 @@ function getDistributionListLabel(contact: { fullName?: string; email: string })
 	return contact.fullName?.trim() ? contact.fullName : contact.email;
 }
 
-function getPersonLabel(contact: {
-	firstName?: string;
-	middleName?: string;
-	lastName?: string;
-	fullName?: string;
-	email: string;
-}): string {
-	const nameParts = [contact.firstName, contact.middleName, contact.lastName].filter(Boolean);
-	if (nameParts.length > 0) {
-		return trim(nameParts.join(' '));
-	}
-	return contact.fullName ?? contact.email;
+/**
+ * Extracts display name from email format like "Display Name" <email@domain.com>
+ * Returns the display name if found, otherwise returns undefined
+ */
+function extractDisplayNameFromEmail(email: string): string | undefined {
+	const match = email.match(/^"([^"]+)"\s*<.+>$/);
+	return match ? match[1].trim() : undefined;
+}
+
+/**
+ * Generates a human-friendly label for a person contact with the following priority:
+ * 1. Use `display` if provided and non-empty.
+ * 2. Use `fullName` if provided and non-empty.
+ * 3. Use a concatenation of `firstName`, `middleName`, and `lastName` if available.
+ * 4. If none of the above are usable, attempt to extract a display name from the email.
+ * 5. Fallback: return the email address itself.
+ */
+function getPersonLabel(
+	contact: {
+		firstName?: string;
+		middleName?: string;
+		lastName?: string;
+		fullName?: string;
+		email: string;
+		display?: string;
+	},
+	originalContactEmail: string | undefined
+): string {
+	const trimValue: (val?: string) => string = (val?: string) => val?.trim() || '';
+
+	// 1. Display field
+	const display = trimValue(contact.display);
+	if (display) return display;
+
+	// 2. Full Name field
+	const fullName = trimValue(contact.fullName);
+	if (fullName) return fullName;
+
+	// 3. Constructed name parts
+	const nameParts = [contact.firstName, contact.middleName, contact.lastName]
+		.map(trimValue)
+		.filter(Boolean);
+	if (nameParts.length > 0) return nameParts.join(' ');
+
+	// 4. Extract from email (before falling back to raw email)
+	const extracted = trimValue(extractDisplayNameFromEmail(originalContactEmail ?? ''));
+	if (extracted) return extracted;
+
+	// 5. Final fallback: email
+	return contact.email;
 }
 
 export const getContactLabel = (
-	contact: ContactInputItemInternalValue | DistributionListContactWithDisplay
+	contact: (ContactInputItemInternalValue | DistributionListContactWithDisplay) & {
+		originalContactEmail?: string;
+	}
 ): string => {
 	if (isGroupContact(contact)) return getGroupLabel(contact);
 	if (isDistributionListContact(contact)) return getDistributionListLabel(contact);
-	return getPersonLabel(contact);
+	return getPersonLabel(contact, contact.originalContactEmail);
 };
 
 export function tryToParseEmail(input: string | undefined): string {
@@ -141,7 +181,9 @@ export const mapToChipContactOptions = (value: RemoteContactResponse): ContactIn
 		fullName: value.full,
 		company: value.company,
 		email: parsedEmail,
-		type: CONTACT_TYPES.CONTACT
+		display: value.display,
+		type: CONTACT_TYPES.CONTACT,
+		originalContactEmail: value.email
 	};
 	const label = getContactLabel(contact);
 	return {

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -70,12 +70,15 @@ function getDistributionListLabel(contact: { fullName?: string; email: string })
  * Returns the display name if found, otherwise returns undefined
  */
 function extractDisplayNameFromEmail(email: string): string | undefined {
-	const match = email.match(/^"([^"]+)"\s*<.+>$/);
+	const match = /^"([^"]+)"\s*<.+>$/.exec(email);
 	return match ? match[1].trim() : undefined;
 }
 
+/**
+ * Trims whitespace from a string value, returning an empty string if the value is undefined or null.
+ */
 function trimValue(val?: string): string {
-	return val?.trim() || '';
+	return val?.trim() ?? '';
 }
 
 /**

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -87,7 +87,7 @@ function trimValue(val?: string): string {
  * 2. Use `fullName` if provided and non-empty.
  * 3. Use a concatenation of `firstName`, `middleName`, and `lastName` if available.
  * 4. If none of the above are usable, attempt to extract a display name from the email.
- * 5. Fallback: return the email address itself.
+ * 5. Fallback: return the `email` address itself.
  */
 function getPersonLabel(
 	contact: {

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -74,6 +74,10 @@ function extractDisplayNameFromEmail(email: string): string | undefined {
 	return match ? match[1].trim() : undefined;
 }
 
+function trimValue(val?: string): string {
+	return val?.trim() || '';
+}
+
 /**
  * Generates a human-friendly label for a person contact with the following priority:
  * 1. Use `display` if provided and non-empty.
@@ -93,8 +97,6 @@ function getPersonLabel(
 	},
 	originalContactEmail: string | undefined
 ): string {
-	const trimValue: (val?: string) => string = (val?: string) => val?.trim() || '';
-
 	// 1. Display field
 	const display = trimValue(contact.display);
 	if (display) return display;
@@ -110,7 +112,7 @@ function getPersonLabel(
 	if (nameParts.length > 0) return nameParts.join(' ');
 
 	// 4. Extract from email (before falling back to raw email)
-	const extracted = trimValue(extractDisplayNameFromEmail(originalContactEmail ?? ''));
+	const extracted = extractDisplayNameFromEmail(originalContactEmail ?? '');
 	if (extracted) return extracted;
 
 	// 5. Final fallback: email

--- a/src/legacy/integrations/tests/contact-input.test.tsx
+++ b/src/legacy/integrations/tests/contact-input.test.tsx
@@ -309,7 +309,7 @@ describe('Contact input', () => {
 
 			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'My fullname' })]);
 		});
-		it('calls onChange with label equal to first + middle + last even if fullname present in autocomplete', async () => {
+		it('calls onChange with label equal to fullName even if first + middle + last present in autocomplete', async () => {
 			const interceptor = createAutocompleteInterceptor([
 				{ email: VALID_EMAIL, full: 'My fullname', first: 'first', middle: 'middle', last: 'last' }
 			]);
@@ -320,10 +320,9 @@ describe('Contact input', () => {
 			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
 			await interceptor;
 
-			expect(onChange).toHaveBeenCalledWith([
-				expect.objectContaining({ label: 'first middle last' })
-			]);
+			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'My fullname' })]);
 		});
+
 		it('calls onChange with a chip with edit action after selecting a simple contact on the dropdown', async () => {
 			const onChange = jest.fn();
 			const autocompleteInterceptor = createAutocompleteInterceptor([
@@ -339,6 +338,107 @@ describe('Contact input', () => {
 				expect.objectContaining({ actions: [editValidChipAction] })
 			]);
 		});
+
+		it('uses display when present, ignoring other name fields', async () => {
+			const interceptor = createAutocompleteInterceptor([
+				{ email: VALID_EMAIL, display: 'Preferred Name', full: 'Full Name', first: 'First' }
+			]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'Preferred Name' })]);
+		});
+
+		it('uses concatenated first + last when no display or fullName', async () => {
+			const interceptor = createAutocompleteInterceptor([
+				{ email: VALID_EMAIL, first: 'First', last: 'Last' }
+			]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'First Last' })]);
+		});
+
+		it('trims whitespace around display before using it', async () => {
+			const interceptor = createAutocompleteInterceptor([
+				{ email: VALID_EMAIL, display: '   My Name   ' }
+			]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'My Name' })]);
+		});
+
+		it('includes middleName in concatenated label', async () => {
+			const interceptor = createAutocompleteInterceptor([
+				{ email: VALID_EMAIL, first: 'First', middle: 'Middle', last: 'Last' }
+			]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([
+				expect.objectContaining({ label: 'First Middle Last' })
+			]);
+		});
+
+		it('ignores empty string fields when concatenating names', async () => {
+			const interceptor = createAutocompleteInterceptor([
+				{ email: VALID_EMAIL, first: 'First', last: '' }
+			]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'First' })]);
+		});
+
+		it('display email if no display, fullName, or name parts', async () => {
+			const interceptor = createAutocompleteInterceptor([{ email: 'john.doe@example.com' }]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, 'john.doe@example.com');
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([
+				expect.objectContaining({ label: 'john.doe@example.com' })
+			]);
+		});
+
+		it('display name from email if no display, fullName, or name parts', async () => {
+			const interceptor = createAutocompleteInterceptor([
+				{ email: '"John Doe" <john.doe@example.com>' }
+			]);
+			const onChange = jest.fn();
+			const { user } = setupTest(
+				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
+			);
+			await typeAndSelectOptionFromDropdown(user, 'john.doe@example.com');
+			await interceptor;
+
+			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'John Doe' })]);
+		});
+
 		it('should show display custom action if provided', async () => {
 			const contactChipItem = createSimpleChip();
 			registerGetDistributionListHandler(generateDistributionList(contactChipItem));

--- a/src/legacy/integrations/tests/contact-input.test.tsx
+++ b/src/legacy/integrations/tests/contact-input.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
+/* eslint-disable @typescript-eslint/no-use-before-define,sonarjs/no-duplicate-string */
 /*
  * SPDX-FileCopyrightText: 2023 Zextras <https://www.zextras.com>
  *

--- a/src/legacy/integrations/tests/contact-input.test.tsx
+++ b/src/legacy/integrations/tests/contact-input.test.tsx
@@ -411,7 +411,7 @@ describe('Contact input', () => {
 			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'First' })]);
 		});
 
-		it('display email if no display, fullName, or name parts', async () => {
+		it('displays email if no display, fullName, or name parts', async () => {
 			const interceptor = createAutocompleteInterceptor([{ email: 'john.doe@example.com' }]);
 			const onChange = jest.fn();
 			const { user } = setupTest(

--- a/src/legacy/integrations/tests/contact-input.test.tsx
+++ b/src/legacy/integrations/tests/contact-input.test.tsx
@@ -425,7 +425,7 @@ describe('Contact input', () => {
 			]);
 		});
 
-		it('display name from email if no display, fullName, or name parts', async () => {
+		it('should display name from email if no display, fullName, or name parts', async () => {
 			const interceptor = createAutocompleteInterceptor([
 				{ email: '"John Doe" <john.doe@example.com>' }
 			]);

--- a/src/legacy/integrations/tests/utils.test.ts
+++ b/src/legacy/integrations/tests/utils.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable sonarjs/no-duplicate-string */
 /*
  * SPDX-FileCopyrightText: 2025 Zextras <https://www.zextras.com>
  *
@@ -48,13 +49,125 @@ describe('utils', () => {
 
 			expect(label).toBe('dl@example.com');
 		});
+
+		// New tests for displayName priority logic
+		it('should prioritize displayName(display) over firstName + lastName for person contact', () => {
+			const personContact = {
+				id: '123456',
+				email: 'john.joe@example.com',
+				display: 'John J. – Sales Team',
+				firstName: 'John',
+				lastName: 'Joe',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John J. – Sales Team');
+		});
+
+		it('should fallback to firstName + lastName when displayName is empty', () => {
+			const personContact = {
+				id: '123424',
+				email: 'john.boe@example.com',
+				display: '',
+				firstName: 'John',
+				lastName: 'Boe',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John Boe');
+		});
+
+		it('should fallback to firstName + lastName when displayName is undefined', () => {
+			const personContact = {
+				id: '123456',
+				email: 'john.toe@example.com',
+				firstName: 'John',
+				lastName: 'Toe',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John Toe');
+		});
+
+		it('should include middle name in firstName + lastName fallback', () => {
+			const personContact = {
+				id: '12346546',
+				email: 'john.poe@example.com',
+				firstName: 'John',
+				middleName: 'Michael',
+				lastName: 'Poe',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John Michael Poe');
+		});
+
+		it('should fallback to fullName when no displayName and no name parts available', () => {
+			const personContact = {
+				id: '12321431',
+				email: 'john.qoe@example.com',
+				fullName: 'John Qoe Full',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John Qoe Full');
+		});
+
+		it('should fallback to email when no displayName, no name parts, and no fullName available', () => {
+			const personContact = {
+				id: 'john.poe@example.com',
+				email: 'john.poe@example.com',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('john.poe@example.com');
+		});
+
+		it('should prioritize displayName over fullName', () => {
+			const personContact = {
+				id: '435345345',
+				email: 'john.loe@example.com',
+				display: 'John L. – Sales Team',
+				fullName: 'John Loe Full',
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John L. – Sales Team');
+		});
+
+		it('should trim whitespace from displayName', () => {
+			const personContact = {
+				id: '1354646',
+				email: 'john.koe@example.com',
+				display: '  John K. – Sales Team  ', // Intentionally added spaces
+				type: CONTACT_TYPES.CONTACT
+			};
+
+			const label = getContactLabel(personContact);
+
+			expect(label).toBe('John K. – Sales Team');
+		});
 	});
 
 	describe('mapToChipContactOptions', () => {
 		it('should create distribution list option with display name from autocomplete response', () => {
 			const autocompleteResponse: RemoteDistributionListContact = {
 				isGroup: true,
-				email: '"MyDistributionList One" <mydist@demo.zextras.io>',
+				email: '"MyDistributionList One" <mydist@example.com>',
 				exp: false,
 				full: 'MyDistributionList One',
 				fileas: '8:MyDistributionList One'
@@ -74,19 +187,19 @@ describe('utils', () => {
 		it('should create distribution list option with parsed email when display name is not available', () => {
 			const autocompleteResponse: RemoteDistributionListContact = {
 				isGroup: true,
-				email: 'mydist@demo.zextras.io',
+				email: 'mydist@example.com',
 				exp: false,
 				full: '',
-				fileas: '8:mydist@demo.zextras.io'
+				fileas: '8:mydist@example.com'
 			};
 
 			const result = mapToChipContactOptions(autocompleteResponse);
 
-			expect(result.label).toBe('mydist@demo.zextras.io');
+			expect(result.label).toBe('mydist@example.com');
 			expect(result.value).toEqual(
 				expect.objectContaining({
 					type: CONTACT_TYPES.DISTRIBUTION_LIST,
-					email: 'mydist@demo.zextras.io',
+					email: 'mydist@example.com',
 					fullName: ''
 				})
 			);
@@ -135,6 +248,68 @@ describe('utils', () => {
 				id: 'test@example.com',
 				customComponent: expect.any(Object)
 			});
+		});
+	});
+
+	describe('extractDisplayNameFromEmail functionality', () => {
+		it('should extract display name from email format and use it in contact mapping', () => {
+			const autocompleteResponse = {
+				isGroup: false,
+				email: '"John Doe" <john.doe@example.com>',
+				first: 'John',
+				last: 'Doe',
+				full: 'John Doe'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			expect(result.label).toBe('John Doe');
+			expect(result.value).toEqual(
+				expect.objectContaining({
+					email: 'john.doe@example.com',
+					firstName: 'John',
+					fullName: 'John Doe',
+					id: 'john.doe@example.com',
+					lastName: 'Doe',
+					type: CONTACT_TYPES.CONTACT
+				})
+			);
+		});
+
+		it('should fallback to firstName + lastName when no display name in email format', () => {
+			const autocompleteResponse = {
+				isGroup: false,
+				email: 'john.doe@gmail.com',
+				first: 'John',
+				last: 'Doe'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			expect(result.label).toBe('John Doe');
+			expect(result.value).toEqual(
+				expect.objectContaining({
+					email: 'john.doe@gmail.com',
+					firstName: 'John',
+					lastName: 'Doe',
+					id: 'john.doe@gmail.com',
+					type: CONTACT_TYPES.CONTACT
+				})
+			);
+		});
+
+		it('should handle email without quotes but with display name structure', () => {
+			const autocompleteResponse = {
+				isGroup: false,
+				email: 'John Doe <john.doe@example.com>',
+				first: 'John',
+				last: 'Doe'
+			};
+
+			const result = mapToChipContactOptions(autocompleteResponse);
+
+			// Since the regex expects quotes, this should fall back to firstName + lastName
+			expect(result.label).toBe('John Doe');
 		});
 	});
 });

--- a/src/legacy/integrations/tests/utils.test.ts
+++ b/src/legacy/integrations/tests/utils.test.ts
@@ -50,7 +50,6 @@ describe('utils', () => {
 			expect(label).toBe('dl@example.com');
 		});
 
-		// New tests for displayName priority logic
 		it('should prioritize displayName(display) over firstName + lastName for person contact', () => {
 			const personContact = {
 				id: '123456',

--- a/src/legacy/integrations/types.ts
+++ b/src/legacy/integrations/types.ts
@@ -41,6 +41,7 @@ export type RemoteUserContact = {
 	middle?: string;
 	full?: string;
 	company?: string;
+	display?: string;
 };
 
 export type RemoteGroupContact = {


### PR DESCRIPTION
Adds support for displaying contact display names as chip labels in `ContactInput` components by prioritizing the display field over other name formats.

- Added display field to the RemoteUserContact type
- Updated label generation logic to prioritize display name over firstName/lastName combination
- Enhanced contact mapping to preserve original email for display name extraction

Additionally: 
- Reverts 28dbc9f6aebb8ae75bf5f3d7ad2d0aab19aff8a4 after talking with  @gjed  (since it fails the pipeline at packaging stage.)
