### PR TITLE
feat: [CO-3030] Remove Contacts's Middle name field

### DIFF
--- a/src/legacy/hooks/use-display-name.ts
+++ b/src/legacy/hooks/use-display-name.ts
@@ -13,16 +13,12 @@ import { Contact } from 'legacy/types/contact';
 
 /*
  * Returns the Display name
- * It will check the firstName, middleName and lastName props in contact and will return in string which are available.
- * If firstName, middleName or lastName not available and email found in contact then will return <No name> with email.
+ * It will check the firstName and lastName props in contact and will return in string which are available.
+ * If firstName or lastName not available and email found in contact then will return <No name> with email.
  */
 export const getDisplayName = (contact: Contact): string | undefined => {
-	if ((contact.firstName || contact.middleName || contact.lastName) && !contact.displayName) {
-		return trim(
-			`${contact.firstName || ''} ${contact.middleName || ''} ${contact.lastName || ''} ${
-				contact.nameSuffix || ''
-			}`
-		);
+	if ((contact.firstName || contact.lastName) && !contact.displayName) {
+		return trim(`${contact.firstName || ''} ${contact.lastName || ''} ${contact.nameSuffix || ''}`);
 	}
 	if (contact.displayName) {
 		return contact.displayName;
@@ -37,8 +33,8 @@ export const getDisplayName = (contact: Contact): string | undefined => {
 
 /*
  * UseDisplayName hook is returning the Display name
- * It will check the firstName, middleName and lastName props in contact and will return in string which are available.
- * If firstName, middleName or lastName not available and email found in contact then will return <No name> with email.
+ * It will check the firstName and lastName props in contact and will return in string which are available.
+ * If firstName or lastName not available and email found in contact then will return <No name> with email.
  */
 export const useDisplayName = (contact: Contact): string => {
 	const [t] = useTranslation();

--- a/src/legacy/integrations/parts/utils.tsx
+++ b/src/legacy/integrations/parts/utils.tsx
@@ -85,14 +85,13 @@ function trimValue(val?: string): string {
  * Generates a human-friendly label for a person contact with the following priority:
  * 1. Use `display` if provided and non-empty.
  * 2. Use `fullName` if provided and non-empty.
- * 3. Use a concatenation of `firstName`, `middleName`, and `lastName` if available.
+ * 3. Use a concatenation of `firstName` and `lastName` if available.
  * 4. If none of the above are usable, attempt to extract a display name from the email.
  * 5. Fallback: return the `email` address itself.
  */
 function getPersonLabel(
 	contact: {
 		firstName?: string;
-		middleName?: string;
 		lastName?: string;
 		fullName?: string;
 		email: string;
@@ -109,9 +108,7 @@ function getPersonLabel(
 	if (fullName) return fullName;
 
 	// 3. Constructed name parts
-	const nameParts = [contact.firstName, contact.middleName, contact.lastName]
-		.map(trimValue)
-		.filter(Boolean);
+	const nameParts = [contact.firstName, contact.lastName].map(trimValue).filter(Boolean);
 	if (nameParts.length > 0) return nameParts.join(' ');
 
 	// 4. Extract from email (before falling back to raw email)
@@ -182,7 +179,6 @@ export const mapToChipContactOptions = (value: RemoteContactResponse): ContactIn
 		id: parsedEmail,
 		firstName: value.first,
 		lastName: value.last,
-		middleName: value.middle,
 		fullName: value.full,
 		company: value.company,
 		email: parsedEmail,

--- a/src/legacy/integrations/tests/contact-input.test.tsx
+++ b/src/legacy/integrations/tests/contact-input.test.tsx
@@ -412,22 +412,6 @@ describe('Contact input', () => {
 			expect(onChange).toHaveBeenCalledWith([expect.objectContaining({ label: 'My Name' })]);
 		});
 
-		it('includes middleName in concatenated label', async () => {
-			const interceptor = createAutocompleteInterceptor([
-				{ email: VALID_EMAIL, first: 'First', middle: 'Middle', last: 'Last' }
-			]);
-			const onChange = vi.fn();
-			const { user } = setupTest(
-				<ContactInput onChange={onChange} defaultValue={[]} orderedAccountIds={[]} />
-			);
-			await typeAndSelectOptionFromDropdown(user, VALID_EMAIL);
-			await interceptor;
-
-			expect(onChange).toHaveBeenCalledWith([
-				expect.objectContaining({ label: 'First Middle Last' })
-			]);
-		});
-
 		it('ignores empty string fields when concatenating names', async () => {
 			const interceptor = createAutocompleteInterceptor([
 				{ email: VALID_EMAIL, first: 'First', last: '' }

--- a/src/legacy/integrations/tests/utils.test.ts
+++ b/src/legacy/integrations/tests/utils.test.ts
@@ -94,21 +94,6 @@ describe('utils', () => {
 			expect(label).toBe('John Toe');
 		});
 
-		it('should include middle name in firstName + lastName fallback', () => {
-			const personContact = {
-				id: '12346546',
-				email: 'john.poe@example.com',
-				firstName: 'John',
-				middleName: 'Michael',
-				lastName: 'Poe',
-				type: CONTACT_TYPES.CONTACT
-			};
-
-			const label = getContactLabel(personContact);
-
-			expect(label).toBe('John Michael Poe');
-		});
-
 		it('should fallback to fullName when no displayName and no name parts available', () => {
 			const personContact = {
 				id: '12321431',

--- a/src/legacy/views/app/folder-panel/tests/drag-items.test.tsx
+++ b/src/legacy/views/app/folder-panel/tests/drag-items.test.tsx
@@ -47,8 +47,8 @@ describe('DragItems', () => {
 
 		const items = screen.getAllByTestId(TESTID_SELECTORS.contactsListItem);
 		expect(items).toHaveLength(2);
-		expect(items[0]).toHaveTextContent(`${con0?.firstName} ${con0?.middleName} ${con0?.lastName}`);
-		expect(items[1]).toHaveTextContent(`${con1?.firstName} ${con1?.middleName} ${con1?.lastName}`);
+		expect(items[0]).toHaveTextContent(`${con0?.firstName} ${con0?.lastName}`);
+		expect(items[1]).toHaveTextContent(`${con1?.firstName} ${con1?.lastName}`);
 	});
 
 	it('ignores invalid IDs that do not match any contact', () => {

--- a/src/legacy/views/edit/edit-view.jsx
+++ b/src/legacy/views/edit/edit-view.jsx
@@ -152,18 +152,16 @@ export default function EditView({ panel, onClose, onTitleChanged }) {
 		() =>
 			contact?.namePrefix ||
 			contact?.firstName ||
-			contact?.middleName ||
 			contact?.nickName ||
 			contact?.lastName ||
 			contact?.nameSuffix
-				? `${contact?.namePrefix ?? ''} ${contact?.firstName ?? ''} ${contact?.middleName ?? ''} ${
+				? `${contact?.namePrefix ?? ''} ${contact?.firstName ?? ''} ${
 						contact?.nickName ?? ''
 					} ${contact?.lastName ?? ''} ${contact?.nameSuffix ?? ''}`
 				: t('label.new_contact', 'New contact'),
 		[
 			contact?.firstName,
 			contact?.lastName,
-			contact?.middleName,
 			contact?.namePrefix,
 			contact?.nameSuffix,
 			contact?.nickName,
@@ -283,12 +281,6 @@ export default function EditView({ panel, onClose, onTitleChanged }) {
 						dispatch={dispatch}
 						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus
-					/>
-					<CustomStringField
-						name="middleName"
-						label={t('name.middle_name', 'Middle Name')}
-						value={contact.middleName}
-						dispatch={dispatch}
 					/>
 				</ContactEditorRow>
 				<ContactEditorRow>

--- a/src/legacy/views/preview/contact-preview-content.jsx
+++ b/src/legacy/views/preview/contact-preview-content.jsx
@@ -259,19 +259,13 @@ function ContactPreviewContent({ contact }) {
 							{contact.namePrefix && (
 								<ContactField field={contact.namePrefix} label={t('name.prefix', 'Prefix')} />
 							)}
-							{contact.firstName && (
-								<ContactField
-									field={contact.firstName}
-									label={t('name.first_name', 'First Name')}
-								/>
-							)}
-							{contact.middleName && (
-								<ContactField
-									field={contact.middleName}
-									label={t('name.middle_name', 'Middle Name')}
-								/>
-							)}
-							{contact.lastName && (
+						{contact.firstName && (
+							<ContactField
+								field={contact.firstName}
+								label={t('name.first_name', 'First Name')}
+							/>
+						)}
+						{contact.lastName && (
 								<ContactField field={contact.lastName} label={t('name.last_name', 'Last Name')} />
 							)}
 							{contact.nameSuffix && (

--- a/src/legacy/views/preview/contact-preview-content.jsx
+++ b/src/legacy/views/preview/contact-preview-content.jsx
@@ -259,13 +259,13 @@ function ContactPreviewContent({ contact }) {
 							{contact.namePrefix && (
 								<ContactField field={contact.namePrefix} label={t('name.prefix', 'Prefix')} />
 							)}
-						{contact.firstName && (
-							<ContactField
-								field={contact.firstName}
-								label={t('name.first_name', 'First Name')}
-							/>
-						)}
-						{contact.lastName && (
+							{contact.firstName && (
+								<ContactField
+									field={contact.firstName}
+									label={t('name.first_name', 'First Name')}
+								/>
+							)}
+							{contact.lastName && (
 								<ContactField field={contact.lastName} label={t('name.last_name', 'Last Name')} />
 							)}
 							{contact.nameSuffix && (

--- a/src/legacy/views/search/search-contact-list-item.tsx
+++ b/src/legacy/views/search/search-contact-list-item.tsx
@@ -31,7 +31,7 @@ export const SearchContactListItem = ({ item }: { item: Contact }): React.JSX.El
 	);
 	const avatarItem = {
 		id: item.id,
-		label: `${item.firstName} ${item.middleName} ${item.lastName}`
+		label: `${item.firstName} ${item.lastName}`
 	};
 	return (
 		<Container orientation="vertical" data-testid={'search-contact-list-item'} onClick={_onClick}>


### PR DESCRIPTION
This PR removes the `middleName` field from the Contacts feature throughout the application.

**Changes:**
- Removed `middleName` from contact display labels and name concatenation logic
- Removed `middleName` input field from the contact edit view
- Removed `middleName` field from the contact preview display
- Updated tests to reflect the removal of `middleName` from expected outputs