### PR TITLE
chore: [CO-3080] vitest configure JUnit reporter to not output in console

### DIFF
--- a/src/legacy/views/search/tests/search-view.test.tsx
+++ b/src/legacy/views/search/tests/search-view.test.tsx
@@ -484,7 +484,6 @@ describe('SearchView', () => {
 			};
 
 			setupTest(<SearchView {...searchViewProps} />);
-			screen.debug();
 			expect(
 				await screen.findByText(
 					/Special characters like :, ", -, !, etc., are ignored in the search/

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,11 @@ import react from '@vitejs/plugin-react';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineConfig } from 'vitest/config';
 
+const junitReporter: ['junit', { outputFile: string; console: boolean }] = [
+	'junit',
+	{ outputFile: 'junit.xml', console: false }
+];
+
 export default defineConfig({
 	plugins: [
 		react({
@@ -25,11 +30,11 @@ export default defineConfig({
 		clearMocks: true,
 		mockReset: true,
 		testTimeout: 20000,
-		reporters: ['default', 'junit'],
+		reporters: ['default', junitReporter],
 		coverage: {
 			enabled: true,
 			provider: 'v8',
-			reporter: ['text', 'cobertura', 'lcov'],
+			reporter: ['cobertura', 'lcov'],
 			reportsDirectory: 'coverage',
 			include: ['src/**/*.{ts,tsx}'],
 			exclude: ['**/__test__/**', '**/tests/**', '**/mocks/**', '**/*.test.{js,jsx,ts,tsx}']


### PR DESCRIPTION
This PR configures Vitest to suppress console output for JUnit and coverage reports while maintaining file-based reporting. The changes reduce console noise during test execution by configuring the JUnit reporter to disable console error logging and removing text-based coverage reporting.

Configured JUnit reporter with `console: false` to suppress console output
Removed `text` coverage reporter (we don't want coverage report in console), keeping only `lcov` and `cobertura` (this one seems to be used by jenkins to collect coverage)