### PR TITLE
fix(ci): migrate Jenkinsfile to jenkins-lib-common

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ packages/react-devtools-fusebox/dist
 packages/react-devtools-inline/dist
 packages/react-devtools-shell/dist
 packages/react-devtools-timeline/dist
+.worktrees/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 library(
-    identifier: 'jenkins-lib-ui@1.0.13',
+    identifier: 'jenkins-lib-common@v2.4.3',
     retriever: modernSCM([
         $class: 'GitSCMSource',
-        credentialsId: 'jenkins-integration-with-github-account',
-        remote: 'git@github.com:zextras/jenkins-lib-ui.git',
+        remote: 'git@github.com:zextras/jenkins-lib-common.git',
+        credentialsId: 'jenkins-integration-with-github-account'
     ])
 )
 
-zappPipeline()
+uiPipeline()


### PR DESCRIPTION
## Summary

`jenkins-lib-ui` has been consolidated into `jenkins-lib-common`. The `uiPipeline()` function (previously `zappPipeline()` in `jenkins-lib-ui`) is now available directly from `jenkins-lib-common` starting at version `v2.4.3`.

## Changes

- Replace `jenkins-lib-ui@1.0.13` library reference with `jenkins-lib-common@v2.4.3`
- Update remote URL from `jenkins-lib-ui.git` to `jenkins-lib-common.git`
- Rename `zappPipeline()` call to `uiPipeline()` (parameters are identical)

No other changes were made to the repository.